### PR TITLE
PullRequest: 27 the use of rtype in Java follows the standard approach

### DIFF
--- a/resource/tag-propagation/lib-func-tag-propagation-rule.json
+++ b/resource/tag-propagation/lib-func-tag-propagation-rule.json
@@ -4,6 +4,7 @@
     "rules": [
       {
         "func": {
+          "calleeType": "System",
           "fsig": "arraycopy",
           "argNum": 5
         },

--- a/src/checker/taint/common-kit/sink-util.ts
+++ b/src/checker/taint/common-kit/sink-util.ts
@@ -101,7 +101,6 @@ function matchSinkAtFuncCallWithCalleeType(
             AstUtilSinkUtil.prettyPrint(fclos.object?.rtype).endsWith(`.${tspec.calleeType}`) ||
             AstUtilSinkUtil.prettyPrint(fclos.object?.rtype?.definiteType) === tspec.calleeType ||
             AstUtilSinkUtil.prettyPrint(fclos.object?.rtype?.definiteType).endsWith(`.${tspec.calleeType}`) ||
-            fclos.object?.rtype?.val?._qid === tspec.calleeType ||
             tspec.calleeType === '*') &&
           AstUtilSinkUtil.prettyPrint(fclos.property) === tspec.fsig
         ) {
@@ -112,7 +111,6 @@ function matchSinkAtFuncCallWithCalleeType(
             AstUtilSinkUtil.prettyPrint(fclos.rtype).endsWith(`.${tspec.calleeType}`) ||
             AstUtilSinkUtil.prettyPrint(fclos.rtype?.definiteType) === tspec.calleeType ||
             AstUtilSinkUtil.prettyPrint(fclos.rtype?.definiteType).endsWith(`.${tspec.calleeType}`) ||
-            fclos.rtype?.val?._qid === tspec.calleeType ||
             tspec.calleeType === '*') &&
           AstUtilSinkUtil.prettyPrint(fclos.ast) === tspec.fsig
         ) {

--- a/src/engine/analyzer/common/analyzer.ts
+++ b/src/engine/analyzer/common/analyzer.ts
@@ -2464,6 +2464,7 @@ class Analyzer extends MemSpace {
           for (let i = 0; i < paramLength; i++) {
             if (
               param[i].varType?.id?.name === argvalues[i].rtype?.definiteType?.name ||
+              argvalues[i].rtype?.definiteType?.name?.endsWith(`.${param[i].varType?.id?.name}`) ||
               (argvalues[i].vtype === 'primitive' && literalTypeList.includes(param[i].varType?.id?.name))
             ) {
               continue


### PR DESCRIPTION
Merge branch 'out2github-benben-20251107 of git@code.alipay.com:UnifiedProgramAnalysis/YASA_ENGINE_OUT.git into master

https://code.alipay.com/UnifiedProgramAnalysis/YASA_ENGINE_OUT/pull_requests/27


Reviewed-by: 颜仪 <wangyayi.wyy@antgroup.com>


* :sparkles: the use of rtype in Java follows the standard approach
* :sparkles: the use of rtype in Java follows the standard approach
* :sparkles: the use of rtype in Java follows the standard approach

## Summary by Sourcery

Standardize rtype assignment and inference in the Java analyzer by always initializing rtype for variables and identifiers, deriving definiteType from symbol or AST nodes, propagating function closure rtype to call results, and improving type matching logic while removing deprecated rtype.val usage.

Enhancements:
- Always initialize rtype for Java variable declarations and infer definiteType from varType or symbol table entries
- Automatically assign rtype to identifiers with definiteType based on class or AST node
- Propagate function closure rtype to call results after execution
- Merge and assign definiteType and vagueType using correct type properties
- Extend parameter matching to accept suffix-based qualified type names
- Remove obsolete rtype.val checks in sink detection to align with new rtype model