### PR TITLE
Out2github jiufo 20251110

### DIFF
--- a/src/checker/taint/js/express/express-taint-checker.ts
+++ b/src/checker/taint/js/express/express-taint-checker.ts
@@ -17,7 +17,6 @@ const logger = require('../../../../util/logger')(__filename)
 
 const TAINT_TAG_NAME = 'EXPRESS_INPUT'
 
-
 /**
  *
  */
@@ -280,8 +279,6 @@ class ExpressTaintChecker extends TaintChecker {
       return
     }
     rules = _.clone(rules)
-    rules = rules.filter((v: any) => v.kind === TAINT_TAG_NAME)
-    if (!rules) return
 
     let matched = false
     rules.some((rule: any) => {

--- a/src/checker/taint/js/js-taint-checker.ts
+++ b/src/checker/taint/js/js-taint-checker.ts
@@ -175,7 +175,7 @@ class JsTaintChecker extends TaintChecker {
 
   /**
    *
-   
+
    * @param analyzer
    * @param scope
    * @param node
@@ -286,13 +286,10 @@ class JsTaintChecker extends TaintChecker {
    * @param scope
    */
   checkByFieldMatch(node: any, fclos: any, argvalues: any, scope: any) {
-    let rules = this.checkerRuleConfigContent.sinks?.FuncCallTaintSink
+    const rules = this.checkerRuleConfigContent.sinks?.FuncCallTaintSink
     if (_.isEmpty(rules)) {
       return
     }
-    rules = _.clone(rules)
-    rules = rules.filter((v: any) => v.kind === TAINT_TAG_NAME_JS_TAINT)
-    if (!rules) return
 
     let matched = false
     rules.some((rule: any) => {

--- a/src/checker/taint/python/python-taint-abstract-checker.ts
+++ b/src/checker/taint/python/python-taint-abstract-checker.ts
@@ -83,13 +83,10 @@ class PythonTaintAbstractChecker extends TaintChecker {
    * @param scope
    */
   checkByFieldMatch(node: any, fclos: any, argvalues: any) {
-    let rules = this.checkerRuleConfigContent.sinks?.FuncCallTaintSink
+    const rules = this.checkerRuleConfigContent.sinks?.FuncCallTaintSink
     if (_.isEmpty(rules)) {
       return
     }
-    rules = _.clone(rules)
-    rules = rules.filter((v: any) => v.kind === TAINT_TAG_NAME_PYTHON)
-    if (!rules) return
     rules.some((rule: any): boolean => {
       if (typeof rule.fsig !== 'string') {
         return false


### PR DESCRIPTION
## Summary by Sourcery

Simplify and streamline rule retrieval logic in JavaScript, Python, and Express taint checkers by using immutable declarations and removing unnecessary cloning and filtering steps.

Enhancements:
- Use const instead of let for rule variables in taint checker modules
- Remove redundant _.clone, filter and existence checks when retrieving sink rules in JS, Python, and Express taint checkers
- Clean up extraneous blank lines and minor formatting in taint checker code