### PR TITLE
add sinks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,4 @@ deps/uast4python
 /workspace/
 deps/uast4py
 src/uast
+src/report

--- a/resource/example-rule-config/rule_config_python.json
+++ b/resource/example-rule-config/rule_config_python.json
@@ -1,169 +1,125 @@
 [
   {
-    "checkerIds": [
-      "taint_flow_python_input",
-      "taint_flow_python_input_inner",
-      "taint_flow_python_django_input"
-    ],
+    "checkerIds": ["taint_flow_python_input", "taint_flow_python_input_inner", "taint_flow_python_django_input"],
     "sources": {
       "FuncCallReturnValueTaintSource": [
         {
           "fsig": "read",
-          "values": [
-            "0"
-          ],
+          "values": ["0"],
           "scopeFile": "all",
           "scopeFunc": "all"
         },
         {
           "fsig": "urlopen",
-          "values": [
-            "0"
-          ],
+          "values": ["0"],
           "scopeFile": "all",
           "scopeFunc": "all"
         },
         {
           "fsig": "parse_qs",
-          "values": [
-            "0"
-          ],
+          "values": ["0"],
           "scopeFile": "all",
           "scopeFunc": "all"
         },
         {
           "fsig": "load",
-          "values": [
-            "0"
-          ],
+          "values": ["0"],
           "scopeFile": "all",
           "scopeFunc": "all"
         },
         {
           "fsig": "get_json",
-          "values": [
-            "0"
-          ],
+          "values": ["0"],
           "scopeFile": "all",
           "scopeFunc": "all"
         },
         {
           "fsig": "body",
-          "values": [
-            "0"
-          ],
+          "values": ["0"],
           "scopeFile": "all",
           "scopeFunc": "all"
         },
         {
           "fsig": "receive_text",
-          "values": [
-            "0"
-          ],
+          "values": ["0"],
           "scopeFile": "all",
           "scopeFunc": "all"
         },
         {
           "fsig": "receive_json",
-          "values": [
-            "0"
-          ],
+          "values": ["0"],
           "scopeFile": "all",
           "scopeFunc": "all"
         },
         {
           "fsig": "get_argument",
-          "values": [
-            "0"
-          ],
+          "values": ["0"],
           "scopeFile": "all",
           "scopeFunc": "all"
         },
         {
           "fsig": "get_arguments",
-          "values": [
-            "0"
-          ],
+          "values": ["0"],
           "scopeFile": "all",
           "scopeFunc": "all"
         },
         {
           "fsig": "json",
-          "values": [
-            "0"
-          ],
+          "values": ["0"],
           "scopeFile": "all",
           "scopeFunc": "all"
         },
         {
           "fsig": "decode_message",
-          "values": [
-            "0"
-          ],
+          "values": ["0"],
           "scopeFile": "all",
           "scopeFunc": "all"
         },
         {
           "fsig": "invocation_metadata",
-          "values": [
-            "0"
-          ],
+          "values": ["0"],
           "scopeFile": "all",
           "scopeFunc": "all"
         },
         {
           "fsig": "read",
-          "values": [
-            "0"
-          ],
+          "values": ["0"],
           "scopeFile": "all",
           "scopeFunc": "all"
         },
         {
           "fsig": "parse_args",
-          "values": [
-            "0"
-          ],
+          "values": ["0"],
           "scopeFile": "all",
           "scopeFunc": "all"
         },
         {
           "fsig": "getenv",
-          "values": [
-            "0"
-          ],
+          "values": ["0"],
           "scopeFile": "all",
           "scopeFunc": "all"
         },
         {
           "fsig": "dotenv_values",
-          "values": [
-            "0"
-          ],
+          "values": ["0"],
           "scopeFile": "all",
           "scopeFunc": "all"
         },
         {
           "fsig": "loads",
-          "values": [
-            "0"
-          ],
+          "values": ["0"],
           "scopeFile": "all",
           "scopeFunc": "all"
         },
         {
           "fsig": "load",
-          "values": [
-            "0"
-          ],
+          "values": ["0"],
           "scopeFile": "all",
           "scopeFunc": "all"
         },
         {
           "fsig": "read_string",
-          "values": [
-            "0"
-          ],
+          "values": ["0"],
           "scopeFile": "all",
           "scopeFunc": "all"
         }
@@ -171,90 +127,67 @@
       "FuncCallArgTaintSource": [
         {
           "fsig": "request",
-          "args": [
-            "*"
-          ],
+          "args": ["*"],
           "scopeFile": "all",
           "scopeFunc": "all"
         },
         {
           "fsig": "on_message",
-          "args": [
-            "0"
-          ],
+          "args": ["0"],
           "scopeFile": "all",
           "scopeFunc": "all"
         },
         {
           "fsig": "on_event",
-          "args": [
-            "1"
-          ],
+          "args": ["1"],
           "scopeFile": "all",
           "scopeFunc": "all"
         },
         {
           "fsig": "on_message",
-          "args": [
-            "0"
-          ],
+          "args": ["0"],
           "scopeFile": "all",
           "scopeFunc": "all"
         },
         {
           "fsig": "handle_request",
-          "args": [
-            "0"
-          ],
+          "args": ["0"],
           "scopeFile": "all",
           "scopeFunc": "all"
         },
         {
           "fsig": "call",
-          "args": [
-            "*"
-          ],
+          "args": ["*"],
           "scopeFile": "all",
           "scopeFunc": "all"
         },
         {
           "fsig": "insecure_channel",
-          "args": [
-            "0"
-          ],
+          "args": ["0"],
           "scopeFile": "all",
           "scopeFunc": "all"
         },
         {
           "fsig": "execute",
-          "args": [
-            "*"
-          ],
+          "args": ["*"],
           "scopeFile": "all",
           "scopeFunc": "all"
         },
         {
           "fsig": "raw",
-          "args": [
-            "*"
-          ],
+          "args": ["*"],
           "scopeFile": "all",
           "scopeFunc": "all"
         },
         {
           "fsig": "get",
-          "args": [
-            "0"
-          ],
+          "args": ["0"],
           "scopeFile": "all",
           "scopeFunc": "all"
         },
         {
           "fsig": "set",
-          "args": [
-            "0",
-            "1"
-          ],
+          "args": ["0", "1"],
           "scopeFile": "all",
           "scopeFunc": "all"
         }
@@ -430,436 +363,317 @@
     "sinks": {
       "FuncCallTaintSink": [
         {
-          "args": [
-            "0"
-          ],
+          "args": ["0"],
+          "attribute": "PythonSSRF",
+          "fregex": "httpx\\.AsyncClient\\s*\\([^)]*\\)\\.get"
+        },
+        {
+          "args": ["0"],
           "attribute": "PythonCodeExec",
           "fsig": "eval"
         },
         {
-          "args": [
-            "0"
-          ],
+          "args": ["0"],
           "attribute": "PythonCodeExec",
           "fsig": "exec"
         },
         {
-          "args": [
-            "0"
-          ],
+          "args": ["0"],
           "attribute": "PythonDeserialization",
           "fsig": "pickle.loads"
         },
         {
-          "args": [
-            "0"
-          ],
+          "args": ["0"],
           "attribute": "PythonDeserialization",
           "fsig": "yaml.load"
         },
         {
-          "args": [
-            "0"
-          ],
+          "args": ["0"],
           "attribute": "PythonSSRF",
           "fsig": "requests.get"
         },
         {
-          "args": [
-            "0"
-          ],
+          "args": ["0"],
           "attribute": "PythonSSRF",
           "fsig": "requests.post"
         },
         {
-          "args": [
-            "0"
-          ],
+          "args": ["0"],
           "attribute": "PythonSSRF",
           "fsig": "http.client.HTTPConnection.request"
         },
         {
-          "args": [
-            "0"
-          ],
+          "args": ["0"],
           "attribute": "PythonSSRF",
           "fsig": "request.urlopen"
         },
         {
-          "args": [
-            "0"
-          ],
+          "args": ["0"],
           "attribute": "PythonCommandExec",
           "fsig": "os.system"
         },
         {
-          "args": [
-            "0"
-          ],
+          "args": ["0"],
           "attribute": "PythonCommandExec",
           "fsig": "os.popen"
         },
         {
-          "args": [
-            "0"
-          ],
+          "args": ["0"],
           "attribute": "PythonCommandExec",
           "fsig": "subprocess.call"
         },
         {
-          "args": [
-            "0"
-          ],
+          "args": ["0"],
           "attribute": "PythonCommandExec",
           "fsig": "subprocess.run"
         },
         {
-          "args": [
-            "0"
-          ],
+          "args": ["0"],
           "attribute": "PythonCommandExec",
           "fsig": "os.execl"
         },
         {
-          "args": [
-            "0"
-          ],
+          "args": ["0"],
           "attribute": "PythonCommandExec",
           "fsig": "os.execle"
         },
         {
-          "args": [
-            "0"
-          ],
+          "args": ["0"],
           "attribute": "PythonCommandExec",
           "fsig": "os.execlp"
         },
         {
-          "args": [
-            "0"
-          ],
+          "args": ["0"],
           "attribute": "PythonCommandExec",
           "fsig": "os.execlpe"
         },
         {
-          "args": [
-            "0"
-          ],
+          "args": ["0"],
           "attribute": "PythonCommandExec",
           "fsig": "os.execv"
         },
         {
-          "args": [
-            "0"
-          ],
+          "args": ["0"],
           "attribute": "PythonCommandExec",
           "fsig": "os.execve"
         },
         {
-          "args": [
-            "0"
-          ],
+          "args": ["0"],
           "attribute": "PythonCommandExec",
           "fsig": "os.execvp"
         },
         {
-          "args": [
-            "0"
-          ],
+          "args": ["0"],
           "attribute": "PythonCommandExec",
           "fsig": "os.execvpe"
         },
         {
-          "args": [
-            "0"
-          ],
+          "args": ["0"],
           "attribute": "PythonTemplateInjection",
           "fsig": "flask.render_template"
         },
         {
-          "args": [
-            "*"
-          ],
+          "args": ["*"],
           "attribute": "Chromium",
           "fsig": "Chromium"
         },
         {
-          "args": [
-            "*"
-          ],
+          "args": ["*"],
           "attribute": "PythonSqlInjection",
           "fsig": "session.execute"
         },
         {
-          "args": [
-            "*"
-          ],
+          "args": ["*"],
           "attribute": "PythonSqlInjection",
           "fsig": "engine.execute"
         },
         {
-          "args": [
-            "*"
-          ],
+          "args": ["*"],
           "attribute": "PythonSqlInjection",
           "fsig": "MyModel.objects.raw"
         },
         {
-          "args": [
-            "*"
-          ],
+          "args": ["*"],
           "attribute": "PythonSqlInjection",
           "fsig": "cursor.execute"
         },
         {
-          "args": [
-            "*"
-          ],
+          "args": ["*"],
           "attribute": "PythonSqlInjection",
           "fsig": "db.execute_sql"
         },
         {
-          "args": [
-            "*"
-          ],
+          "args": ["*"],
           "attribute": "PythonSqlInjection",
           "fsig": "MyModel.raw"
         },
         {
-          "args": [
-            "*"
-          ],
+          "args": ["*"],
           "attribute": "PythonCommandInjection",
           "fsig": "os.system"
         },
         {
-          "args": [
-            "*"
-          ],
+          "args": ["*"],
           "attribute": "PythonCommandInjection",
           "fsig": "os.popen"
         },
         {
-          "args": [
-            "*"
-          ],
+          "args": ["*"],
           "attribute": "PythonCommandInjection",
           "fsig": "subprocess.run"
         },
         {
-          "args": [
-            "*"
-          ],
+          "args": ["*"],
           "attribute": "PythonCommandInjection",
           "fsig": "subprocess.Popen"
         },
         {
-          "args": [
-            "*"
-          ],
+          "args": ["*"],
           "attribute": "PythonCommandInjection",
           "fsig": "asyncio.create_subprocess_shell"
         },
         {
-          "args": [
-            "*"
-          ],
+          "args": ["*"],
           "attribute": "PythonPathTraversal",
           "fsig": "open"
         },
         {
-          "args": [
-            "*"
-          ],
+          "args": ["*"],
           "attribute": "PythonPathTraversal",
           "fsig": "pathlib.Path.write_text"
         },
         {
-          "args": [
-            "*"
-          ],
+          "args": ["*"],
           "attribute": "PythonPathTraversal",
           "fsig": "shutil.move"
         },
         {
-          "args": [
-            "*"
-          ],
+          "args": ["*"],
           "attribute": "PythonPathTraversal",
           "fsig": "os.rename"
         },
         {
-          "args": [
-            "*"
-          ],
+          "args": ["*"],
           "attribute": "PythonPathTraversal",
           "fsig": "os.remove"
         },
         {
-          "args": [
-            "*"
-          ],
+          "args": ["*"],
           "attribute": "PythonPathTraversal",
           "fsig": "Flask.send_from_directory"
         },
         {
-          "args": [
-            "*"
-          ],
+          "args": ["*"],
           "attribute": "PythonPathTraversal",
           "fsig": "aiofiles.open"
         },
         {
-          "args": [
-            "*"
-          ],
+          "args": ["*"],
           "attribute": "PythonSSRF",
           "fsig": "requests.get"
         },
         {
-          "args": [
-            "*"
-          ],
+          "args": ["*"],
           "attribute": "PythonSSRF",
           "fsig": "requests.post"
         },
         {
-          "args": [
-            "*"
-          ],
+          "args": ["*"],
           "attribute": "PythonSSRF",
           "fsig": "urllib.request.urlopen"
         },
         {
-          "args": [
-            "*"
-          ],
+          "args": ["*"],
           "attribute": "PythonSSRF",
           "fsig": "httpx.AsyncClient.get"
         },
         {
-          "args": [
-            "*"
-          ],
+          "args": ["*"],
           "attribute": "PythonSSRF",
           "fsig": "smtplib.SMTP.sendmail"
         },
         {
-          "args": [
-            "*"
-          ],
+          "args": ["*"],
           "attribute": "PythonTemplateInjection",
           "fsig": "Template.render"
         },
         {
-          "args": [
-            "*"
-          ],
+          "args": ["*"],
           "attribute": "PythonTemplateInjection",
           "fsig": "django.shortcuts.render"
         },
         {
-          "args": [
-            "*"
-          ],
+          "args": ["*"],
           "attribute": "PythonTemplateInjection",
           "fsig": "Template.render"
         },
         {
-          "args": [
-            "*"
-          ],
+          "args": ["*"],
           "attribute": "PythonXSS",
           "fsig": "fastapi.responses.HTMLResponse"
         },
         {
-          "args": [
-            "*"
-          ],
+          "args": ["*"],
           "attribute": "PythonLogInjection",
           "fsig": "logging.Logger.info"
         },
         {
-          "args": [
-            "*"
-          ],
+          "args": ["*"],
           "attribute": "PythonLogInjection",
           "fsig": "logging.Logger.error"
         },
         {
-          "args": [
-            "*"
-          ],
+          "args": ["*"],
           "attribute": "PythonLogInjection",
           "fsig": "structlog.get_logger().msg"
         },
         {
-          "args": [
-            "*"
-          ],
+          "args": ["*"],
           "attribute": "PythonDeserializationGadget",
           "fsig": "pickle.dump"
         },
         {
-          "args": [
-            "*"
-          ],
+          "args": ["*"],
           "attribute": "PythonDeserializationGadget",
           "fsig": "pickle.dumps"
         },
         {
-          "args": [
-            "*"
-          ],
+          "args": ["*"],
           "attribute": "PythonDeserializationGadget",
           "fsig": "yaml.dump"
         },
         {
-          "args": [
-            "*"
-          ],
+          "args": ["*"],
           "attribute": "PythonDeserializationGadget",
           "fsig": "json.xxdumps"
         },
         {
-          "args": [
-            "*"
-          ],
+          "args": ["*"],
           "attribute": "PythonResponseWrite",
           "fsig": "flask.Response"
         },
         {
-          "args": [
-            "*"
-          ],
+          "args": ["*"],
           "attribute": "PythonResponseWrite",
           "fsig": "fastapi.Response"
         },
         {
-          "args": [
-            "*"
-          ],
+          "args": ["*"],
           "attribute": "PythonResponseWrite",
           "fsig": "django.http.HttpResponse"
         },
         {
-          "args": [
-            "*"
-          ],
+          "args": ["*"],
           "attribute": "PythonInfoLeak",
           "fsig": "traceback.print_exc"
         },
         {
-          "args": [
-            "*"
-          ],
+          "args": ["*"],
           "attribute": "PythonInfoLeak",
           "fsig": "logging.exception"
         },
         {
-          "args": [
-            "*"
-          ],
+          "args": ["*"],
           "attribute": "PythonInfoLeak",
           "fsig": "django.settings.SECRET_KEY"
         }

--- a/src/checker/taint/go/main-entrypoint-collect-checker.ts
+++ b/src/checker/taint/go/main-entrypoint-collect-checker.ts
@@ -2,7 +2,7 @@ import type { EntryPoint } from '../../../engine/analyzer/common/entrypoint'
 
 const _ = require('lodash')
 const GoEntryPoint = require('../../../engine/analyzer/golang/common/entrypoint-collector/go-default-entrypoint')
-const completeEntryPoint = require('../common-kit/entry-points-util')
+const { completeEntryPoint } = require('../common-kit/entry-points-util')
 const Config = require('../../../config')
 const Checker = require('../../common/checker')
 

--- a/src/interface/starter.ts
+++ b/src/interface/starter.ts
@@ -251,7 +251,7 @@ async function initAnalyzer(dir: any, args: any[] = [], printf: any) {
     printHelp()
   })
 
-  program.version('0.2.4-inner')
+  program.version('0.2.6-inner')
 
   // 解析命令行参数
   program.parse(args, { from: 'user' })


### PR DESCRIPTION
## Summary by Sourcery

Refactor import syntax for completeEntryPoint in Go taint checker and bump CLI version to 0.2.6-inner

Enhancements:
- Destructure completeEntryPoint import in the Go taint entrypoint collector

Chores:
- Bump program version in the CLI interface
- Apply minor import cleanup