### PR TITLE
fix: use CommonJS require for sym-address in python-analyzer

### DIFF
--- a/src/engine/analyzer/python/common/python-analyzer.ts
+++ b/src/engine/analyzer/python/common/python-analyzer.ts
@@ -1,4 +1,4 @@
-import SymAddress from '../../common/sym-address'
+const SymAddress = require('../../common/sym-address')
 
 const { Analyzer } = require('../../common')
 const CheckerManager = require('../../common/checker-manager')


### PR DESCRIPTION
## Description
Fix TypeScript compilation error (TS1192) caused by incompatible import syntax.

Fixes #54

## Changes
- Changed `python-analyzer.ts:1` from ES6 default import to CommonJS `require()`
- Aligns with the existing code style used throughout the project

## Testing
- [x] `npx tsc` compiles successfully
- [x] `node dist/main.js --help` runs correctly

## Summary by Sourcery

Bug Fixes:
- Replace ES6 default import of SymAddress with CommonJS require in python-analyzer to fix TS1192 error