### PR TITLE
fixbug: filter class instance objects in call graph construction

### DIFF
--- a/src/checker/callgraph/callgraph-checker.ts
+++ b/src/checker/callgraph/callgraph-checker.ts
@@ -88,6 +88,9 @@ class CallgraphChecker extends CheckerCallgraph {
 
     const from = stack[stack.length - 1] || { name: '<__entry_point__>', sid: '<__entry_point__>', vtype: 'fclos' }
     const fromAST = from.fdef
+    if (fromAST && fromAST.type !== 'FunctionDefinition' && from.vtype !== 'fclos') {
+      return
+    }
     const callgraph = (ainfo.callgraph = ainfo.callgraph || new this.kit.Graph())
     const fromNode = callgraph.addNode(this.prettyPrint(from, fromAST, call_site_node), {
       funcDef: fromAST,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds a guard to skip creating call graph edges when the caller is not a `FunctionDefinition` or `fclos`.
> 
> - **Callgraph construction (`src/checker/callgraph/callgraph-checker.ts`)**:
>   - Add guard in `triggerAtFunctionCallBefore` to return early when `fromAST` exists but `fromAST.type !== 'FunctionDefinition'` and `from.vtype !== 'fclos'`.
>   - Effect: do not add nodes/edges for calls originating from non-function callers (e.g., class instance objects).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a2f4324ccd563a33d484c625bb3ee20b2487ec6b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

## Summary by Sourcery

Bug Fixes:
- Avoid constructing call graph entries for class instance or non-function objects by returning early when the current context is not a function definition or closure.