### PR TITLE
PullRequest: 45 基于类型分析的CallGraph构建

### DIFF
--- a/src/checker/callgraph/callgraph-checker.ts
+++ b/src/checker/callgraph/callgraph-checker.ts
@@ -1,5 +1,6 @@
 // used for dump call graph
 import type { IConfig } from '../../config'
+import type TypeRelatedInfoResolver from '../../resolver/common/type-related-info-resolver'
 
 const _ = require('lodash')
 const symAddressCallgraph = require('../../engine/analyzer/common/sym-address')
@@ -51,7 +52,12 @@ class CallgraphChecker extends CheckerCallgraph {
   triggerAtStartOfAnalyze(analyzer: any, scope: any, node: any, state: any, info: any): void {
     if (configCallgraph.dumpAllCG) {
       const fullCallGraphFileEntryPoint = require('../common/full-callgraph-file-entrypoint')
-      fullCallGraphFileEntryPoint.makeFullCallGraph(analyzer)
+      const typeResolver: TypeRelatedInfoResolver | undefined = this.getTypeResolver(analyzer)
+      if (typeResolver) {
+        fullCallGraphFileEntryPoint.makeFullCallGraphByType(analyzer, typeResolver)
+      } else {
+        fullCallGraphFileEntryPoint.makeFullCallGraph(analyzer)
+      }
     }
   }
 
@@ -217,6 +223,19 @@ class CallgraphChecker extends CheckerCallgraph {
     const endLine = ast && ast.loc.end.line
 
     return ` \\n[${sourcefile} : ${startLine}_${endLine}]`
+  }
+
+  /**
+   * get type resolver
+   * @param analyzer
+   * @returns {TypeRelatedInfoResolver|undefined}
+   */
+  getTypeResolver(analyzer: any): TypeRelatedInfoResolver | undefined {
+    let resolver: TypeRelatedInfoResolver | undefined
+    if (configCallgraph.cgAlgo === 'CHA') {
+      resolver = analyzer.typeResolver
+    }
+    return resolver
   }
 }
 

--- a/src/checker/taint/go/go-default-taint-checker.ts
+++ b/src/checker/taint/go/go-default-taint-checker.ts
@@ -74,7 +74,11 @@ class GoDefaultTaintChecker extends TaintChecker {
 
     // 使用callGraph边界作为entrypoint
     if (Config.entryPointMode !== 'ONLY_CUSTOM') {
-      FullCallGraphFileEntryPoint.makeFullCallGraph(analyzer)
+      if (Config.cgAlgo === 'CHA' && analyzer.typeResolver) {
+        FullCallGraphFileEntryPoint.makeFullCallGraphByType(analyzer, analyzer.typeResolver)
+      } else {
+        FullCallGraphFileEntryPoint.makeFullCallGraph(analyzer)
+      }
       const fullCallGraphEntrypoint = FullCallGraphFileEntryPoint.getAllEntryPointsUsingCallGraph(
         analyzer.ainfo?.callgraph
       )

--- a/src/checker/taint/java/java-default-taint-checker.ts
+++ b/src/checker/taint/java/java-default-taint-checker.ts
@@ -81,7 +81,11 @@ class JavaDefaultTaintChecker extends JavaTaintAbstractChecker {
         })
       }
 
-      FullCallGraphFileEntryPoint.makeFullCallGraph(analyzer)
+      if (Config.cgAlgo === 'CHA' && analyzer.typeResolver) {
+        FullCallGraphFileEntryPoint.makeFullCallGraphByType(analyzer, analyzer.typeResolver)
+      } else {
+        FullCallGraphFileEntryPoint.makeFullCallGraph(analyzer)
+      }
       const fullCallGraphEntrypoint = FullCallGraphFileEntryPoint.getAllEntryPointsUsingCallGraph(
         analyzer.ainfo?.callgraph
       )

--- a/src/config.ts
+++ b/src/config.ts
@@ -52,6 +52,7 @@ export interface IConfig {
   checkerPackIds?: string[]
   entryPointAndSourceAtSameTime?: boolean
   entryPointMode?: string
+  cgAlgo: string
 
   // Allow additional properties
   [key: string]: any
@@ -120,6 +121,9 @@ const configObject: IConfig = {
   checkerPackIds: [],
   entryPointAndSourceAtSameTime: true,
   entryPointMode: 'BOTH', // BOTH or ONLY_CUSTOM or SELF_COLLECT
+
+  // CallGraph
+  cgAlgo: 'DEFAULT',
 }
 
 module.exports = configObject

--- a/src/engine/analyzer/common/memSpace.ts
+++ b/src/engine/analyzer/common/memSpace.ts
@@ -141,10 +141,11 @@ class MemSpace extends Scope {
    * @param scope
    * @param node  node value, this should not be raw uast node
    * @param state
+   * @param limit
    * @returns {{type, object, property}|*}
    */
-  getMemberValueNoCreate(scope: any, node: any, state: any): any {
-    return this._getMemberValue(scope, node, state, false)
+  getMemberValueNoCreate(scope: any, node: any, state: any, limit?: number): any {
+    return this._getMemberValue(scope, node, state, false, limit)
   }
 
   /**

--- a/src/engine/analyzer/golang/common/go-analyzer.ts
+++ b/src/engine/analyzer/golang/common/go-analyzer.ts
@@ -1,3 +1,5 @@
+import GoTypeRelatedInfoResolver from '../../../../resolver/go/go-type-related-info-resolver'
+
 const logger = require('../../../../util/logger')(__filename)
 const Scope = require('../../common/scope')
 const { Analyzer } = require('../../common')
@@ -71,6 +73,7 @@ class GoAnalyzer extends Analyzer {
     this.options = options
     this.mainEntryPoints = []
     this.ruleEntrypoints = []
+    this.typeResolver = new GoTypeRelatedInfoResolver()
   }
 
   /**

--- a/src/engine/analyzer/java/common/java-analyzer.ts
+++ b/src/engine/analyzer/java/common/java-analyzer.ts
@@ -1,4 +1,6 @@
 /* eslint-disable @typescript-eslint/naming-convention, @typescript-eslint/no-unused-vars, @typescript-eslint/no-use-before-define */
+import JavaTypeRelatedInfoResolver from '../../../../resolver/java/java-type-related-info-resolver'
+
 const _ = require('lodash')
 const fs = require('fs')
 const path = require('path')
@@ -41,6 +43,7 @@ class JavaAnalyzer extends (Analyzer as any) {
     )
     super(checkerManager, options)
     this.classMap = new Map()
+    this.typeResolver = new JavaTypeRelatedInfoResolver()
   }
 
   /**

--- a/src/interface/starter.ts
+++ b/src/interface/starter.ts
@@ -251,6 +251,9 @@ async function initAnalyzer(dir: any, args: any[] = [], printf?: any) {
         Config.incremental = mode === 'true' || mode === true || mode === '1' || mode === 1
       }
     })
+    .option('--cgAlgo <cgAlgo>', '指定构建CallGraph的算法', (cgAlgo: any) => {
+      Config.cgAlgo = cgAlgo
+    })
   // 处理非选项参数（如直接传入的目录）
   program.arguments('[paths...]').action((paths: any) => {
     if (paths.length > 0) {

--- a/src/resolver/go/go-type-related-info-resolver.ts
+++ b/src/resolver/go/go-type-related-info-resolver.ts
@@ -1,0 +1,18 @@
+import TypeRelatedInfoResolver from '../common/type-related-info-resolver'
+import type { ClassHierarchy } from '../common/value/class-hierarchy'
+
+/**
+ * 多态性还未实现，暂不建议使用
+ */
+export default class GoTypeRelatedInfoResolver extends TypeRelatedInfoResolver {
+  /**
+   * find class hierarchy
+   * @param analyzer
+   * @param state
+   * @returns {Map<string, ClassHierarchy>}
+   */
+  findClassHierarchy(analyzer: any, state: any): Map<string, ClassHierarchy> {
+    // TODO
+    return new Map()
+  }
+}

--- a/src/resolver/java/java-type-related-info-resolver.ts
+++ b/src/resolver/java/java-type-related-info-resolver.ts
@@ -1,0 +1,72 @@
+import TypeRelatedInfoResolver from '../common/type-related-info-resolver'
+import type { ClassHierarchy } from '../common/value/class-hierarchy'
+
+/**
+ * JavaTypeRelatedInfoResolver
+ */
+export default class JavaTypeRelatedInfoResolver extends TypeRelatedInfoResolver {
+  /**
+   * find class hierarchy
+   * @param analyzer
+   * @param state
+   * @returns {Map<string, ClassHierarchy>}
+   */
+  findClassHierarchy(analyzer: any, state: any): Map<string, ClassHierarchy> {
+    const resultMap: Map<string, ClassHierarchy> = new Map()
+    if (!analyzer.classMap) {
+      return resultMap
+    }
+
+    for (const classVal of analyzer.classMap.values()) {
+      if (!classVal.ast) {
+        continue
+      }
+
+      let classHierarchy = resultMap.get(classVal._qid)
+      if (!classHierarchy) {
+        classHierarchy = {
+          typeDeclaration: classVal.ast._meta?.typeDeclaration ? classVal.ast._meta.typeDeclaration : 'class',
+          type: classVal._qid,
+          value: classVal,
+          extends: [],
+          extendedBy: [],
+          implements: [],
+          implementedBy: [],
+        }
+        resultMap.set(classVal._qid, classHierarchy)
+      }
+
+      if (!Array.isArray(classVal.ast?.supers) || classVal.ast.supers.length === 0) {
+        continue
+      }
+
+      for (const superAst of classVal.ast.supers) {
+        const superClsVal = this.getMemberValueNoCreate(classVal, superAst, state)
+        const superClsName = superClsVal ? superClsVal._qid : superAst.name
+        let superClassHierarchy = resultMap.get(superClsName)
+        if (!superClassHierarchy) {
+          superClassHierarchy = {
+            typeDeclaration: superClsVal?.ast?._meta?.typeDeclaration ? superClsVal.ast._meta.typeDeclaration : 'class',
+            type: superClsName,
+            value: superClsVal,
+            extends: [],
+            extendedBy: [],
+            implements: [],
+            implementedBy: [],
+          }
+          resultMap.set(superClsName, superClassHierarchy)
+        }
+
+        if (classHierarchy.typeDeclaration === 'class' && superClassHierarchy.typeDeclaration === 'interface') {
+          classHierarchy.implements.push(superClassHierarchy)
+          superClassHierarchy.implementedBy.push(classHierarchy)
+        } else {
+          classHierarchy.extends.push(superClassHierarchy)
+          superClassHierarchy.extendedBy.push(classHierarchy)
+        }
+      }
+    }
+
+    return resultMap
+  }
+}

--- a/src/util/graph.ts
+++ b/src/util/graph.ts
@@ -80,20 +80,30 @@ class GraphClass {
   dumpGraph(): { nodes: Record<string, any>; edges: Record<string, any> } {
     const newEdges = [...this.edges.entries()]
       .filter(([key, value]) => !key.includes('entry_point'))
-      .reduce((acc, [key, value]) => {
-        const { opts, ...otherField } = value
-        const { callSite, ...rest } = opts
-        acc[key] = { ...otherField, callSite: { loc: callSite?.loc }, ...rest }
-        return acc
-      }, {} as Record<string, any>)
+      .reduce(
+        (acc, [key, value]) => {
+          const { opts, ...otherField } = value
+          const { callSite, ...rest } = opts
+          acc[key] = { ...otherField, callSite: { loc: callSite?.loc }, ...rest }
+          return acc
+        },
+        {} as Record<string, any>
+      )
     const newNodes = [...this.nodes.entries()]
       .filter(([key, value]) => !key.includes('entry_point'))
-      .reduce((acc, [key, value]) => {
-        const { opts, ...otherField } = value
-        const { funcDef, funcSymbol } = opts
-        acc[key] = { ...otherField, funcDef: { loc: funcDef?.loc, name: funcDef?.name }, fullName: funcSymbol?._qid }
-        return acc
-      }, {} as Record<string, any>)
+      .reduce(
+        (acc, [key, value]) => {
+          const { opts, ...otherField } = value
+          const { funcDef, funcSymbol } = opts
+          acc[key] = {
+            ...otherField,
+            funcDef: { loc: funcDef?.loc, name: funcDef?.name },
+            fullName: funcSymbol?._qid ? funcSymbol?._qid : key,
+          }
+          return acc
+        },
+        {} as Record<string, any>
+      )
     return {
       nodes: newNodes,
       edges: newEdges,


### PR DESCRIPTION
Merge branch 'out2github-benben-20251124 of git@code.alipay.com:UnifiedProgramAnalysis/YASA_ENGINE_OUT.git into master

https://code.alipay.com/UnifiedProgramAnalysis/YASA_ENGINE_OUT/pull_requests/45


Reviewed-by: 九佛 <shishaosen.sss@antgroup.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduce CHA type-based call graph option with Java/Go type resolvers; wire into callgraph/taint checkers, config/CLI, and refine graph dump.
> 
> - **Call Graph**:
>   - Add CHA-based type-driven construction: use `makeFullCallGraphByType` when `Config.cgAlgo === 'CHA'` in `callgraph-checker`, `go-default-taint-checker`, and `java-default-taint-checker`.
>   - Enhance node dump: include fallback `fullName` (`funcSymbol?._qid` or node id) in `util/graph.ts`.
> - **Analyzers & Resolvers**:
>   - Initialize `typeResolver` in `GoAnalyzer` and `JavaAnalyzer` using new resolvers.
>   - New resolvers: `resolver/java/java-type-related-info-resolver.ts` (builds class hierarchy), `resolver/go/go-type-related-info-resolver.ts` (stub).
> - **Config & CLI**:
>   - Add `cgAlgo` to `IConfig` with default `'DEFAULT'`; new CLI option `--cgAlgo` to select algorithm.
> - **Core API**:
>   - Extend `MemSpace.getMemberValueNoCreate` to accept optional `limit` parameter.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8fb3594f0ffb9a094b9334a9f18ce8bdd0ad8a7a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

## Summary by Sourcery

Introduce configurable, type-based call graph construction and enrich graph node metadata fallbacks.

New Features:
- Add support for a configurable call graph algorithm, including a CHA-based, type-aware variant selectable via CLI and config.
- Introduce Java and Go type-related info resolvers to provide class hierarchy data for call graph construction.

Enhancements:
- Fallback to node keys when function symbols are missing in graph dumps to ensure stable node identifiers.
- Initialize language-specific analyzers with corresponding type resolvers and thread them into call graph and taint analysis flows.
- Extend memory space member lookup to accept an optional limit parameter for more flexible resolution.