### PR TITLE
workflows: use zip/unzip to keep execution permission

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,6 +64,7 @@ jobs:
             echo "❌ Failed to download UAST binaries"
             exit 1
           fi
+          chmod +x uast_binaries/*
           ls -lh uast_binaries/
 
       - name: Extract and Deploy Linux Binaries to deps/


### PR DESCRIPTION
Use zip/unzip to keep execution permission when uploading and downloading artifacts.

The modification is not tested locally because I failed to setup github runner docker container through [act](https://github.com/nektos/act). The required space for the github runner is large.

Fixes #96.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes GitHub Actions release packaging by switching artifacts from directories to zipped archives and adds unzip steps; this can break the release pipeline if paths or extraction assumptions are wrong, but does not affect runtime code.
> 
> **Overview**
> Updates `release.yml` to preserve executable bits across GitHub Actions artifacts by **zipping UAST and engine build outputs before upload** and **unzipping after download**.
> 
> UAST assets now get `chmod +x`, are compressed into `uast-binaries.zip`, and downstream jobs extract from the zip instead of relying on `download-artifact` directory semantics.
> 
> Engine build artifacts are similarly packaged as `engine-<target>.zip` (containing `dist/` and `node_modules/`), and `package_release` downloads merged artifacts and unpacks them before creating the final platform release zips.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b846f14ada51d751ced0c4cac207665edd4f80f0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->