### PR TITLE
fix(python): only create subscope for FunctionDefinition

### DIFF
--- a/src/engine/analyzer/python/common/python-analyzer.ts
+++ b/src/engine/analyzer/python/common/python-analyzer.ts
@@ -744,7 +744,11 @@ class PythonAnalyzer extends (Analyzer as any) {
       } else {
         scopeName = `<block_${Uuid.v4()}>`
       }
-      const block_scope = Scope.createSubScope(scopeName, scope, 'scope')
+      let block_scope = scope
+      if (node.parent?.type === 'FunctionDefinition') {
+        // 只对函数体内的块语句创建子作用域，python的其他块语句不创建子作用域
+        block_scope = Scope.createSubScope(scopeName, scope, 'scope')
+      }
       node.body
         .filter((n: any) => needCompileFirst(n.type))
         .forEach((s: any) => this.processInstruction(block_scope, s, state))


### PR DESCRIPTION
After investigating YASA-UAST python parser, I found that make subscope only when parent is `FunctionDefinition` is enough for fixing this bug.

There are 9 situations that generates `ScopedStatement`
1. FunctionDef
2. ClassDef
3. If
4. While
5. For
6. Lambda
7. List Comprehension
8. Try/Catch
9. Match/Case

We check `FunctionDefinition` so 1 is OK

For 2 and 6, the parser generates `FunctionDefinition` as parent of `ScopedStatement`, so we covered these situations:
https://github.com/antgroup/YASA-UAST/blob/3bc130288bbf8135fe3ba8f945e225ea861d386f/parser-Python/uast/visitor.py#L352-L359
https://github.com/antgroup/YASA-UAST/blob/3bc130288bbf8135fe3ba8f945e225ea861d386f/parser-Python/uast/visitor.py#L813-L816

For 3, 4, 5, 7, 8 and 9, they aren't defining variable scopes in python syntax, so this is the bug per se and we shouldn't make subscope for them.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adjusts Python block scoping to align with Python semantics.
> 
> - In `python-analyzer.ts` `processScopedStatement`, only create a new `scope` for block statements whose parent is `FunctionDefinition`; otherwise reuse the current `scope`
> - Keeps existing processing order (`needCompileFirst` vs non-first) and `TryStatement` handling unchanged
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 90ff6bb91f81cdee5e457d1a939ed1110837ac0e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->