### PR TITLE
feat(mcp): bootstrap_mcp_framework — YASA-MCP 统一运行底座脚手架 (#129)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,10 @@ TODO.md
 *.LICENSE.txt
 gulpfile_sym.js
 yasa*
+# yasa_mcp 是 MCP 框架脚手架源码，必须纳入版本管理（不被上面的 yasa* 吞掉）
+!yasa_mcp/
+!yasa_mcp/**
+.pytest_cache/
 e2e_chair.test.js
 package-lock.json
 test.js

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,22 @@
+[project]
+name = "yasa-mcp"
+version = "0.1.0"
+description = "YASA-Engine [OSS26] MCP 统一运行底座脚手架（bootstrap_mcp_framework）"
+readme = "yasa_mcp/README.md"
+requires-python = ">=3.10"
+dependencies = [
+    "fastmcp>=3.0.0,<4.0.0",
+    "click>=8.1.0",
+    "pydantic>=2.5.0",
+    "uvicorn>=0.27.0",
+    "starlette>=0.37.0",
+]
+
+[project.optional-dependencies]
+dev = ["pytest>=8.0.0"]
+
+[project.scripts]
+yasa-mcp = "yasa_mcp.__main__:main"
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,4 @@
+# YASA-Engine [OSS26] MCP 脚手架 —— 开发 / 测试依赖
+# 安装：pip install -r requirements-dev.txt
+-r requirements.txt
+pytest>=8.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,8 @@
+# YASA-Engine [OSS26] MCP 统一运行底座脚手架 —— 运行依赖
+# 安装：pip install -r requirements.txt
+# fastmcp 3.x 起使用 http_app / custom_route 新 API
+fastmcp>=3.0.0,<4.0.0
+click>=8.1.0
+pydantic>=2.5.0
+uvicorn>=0.27.0
+starlette>=0.37.0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,63 @@
+# -*- coding: utf-8 -*-
+"""
+tests/conftest.py —— pytest 公共配置
+=====================================
+
+负责：
+    1. 把项目根目录加入 sys.path，保证 `import yasa_mcp` 在任何目录运行 pytest 都成功；
+    2. 兜底设置脚手架强校验的环境变量 YASA_MCP_REPO_ROOT（指向项目根目录）；
+    3. 提供通用的测试工具 / 测试服务器 fixture。
+"""
+from __future__ import annotations
+
+import asyncio
+import os
+import sys
+
+import pytest
+
+# 项目根目录 = 本文件的上两级目录
+PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if PROJECT_ROOT not in sys.path:
+    sys.path.insert(0, PROJECT_ROOT)
+
+# 脚手架强校验环境变量 YASA_MCP_REPO_ROOT，测试期间兜底设置为项目根目录
+os.environ.setdefault("YASA_MCP_REPO_ROOT", PROJECT_ROOT)
+
+from yasa_mcp.decorators import mcp_tool  # noqa: E402
+
+
+def run(coro):
+    """在同步测试函数中运行协程的辅助函数（避免引入 pytest-asyncio）。"""
+    return asyncio.run(coro)
+
+
+@pytest.fixture
+def make_tool_server():
+    """
+    工厂 fixture：把给定函数用 @mcp_tool 注册到一个全新的 FastMCP 实例上。
+
+    用法：
+        def test_xxx(make_tool_server):
+            mcp, tool_name = make_tool_server(
+                name="greet",
+                func=lambda: {"ok": True},   # 或 async def 函数
+            )
+    """
+    from fastmcp import FastMCP
+
+    created = []
+
+    def _make(name: str, func=None, description: str = "test tool"):
+        nonlocal created
+        mcp = FastMCP("test-server")
+        decorated = mcp_tool(name=name, description=description)(func)
+        mcp.tool(name=name, description=description)(decorated)
+        created.append(mcp)
+        return mcp, name
+
+    yield _make
+
+    # 清理：确保不再引用测试实例
+    for mcp in created:
+        pass

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,100 @@
+# -*- coding: utf-8 -*-
+"""
+test_config.py —— 配置加载与环境变量强校验测试
+==============================================
+"""
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from yasa_mcp.config import (
+    ConfigError,
+    ENV_LOG_LEVEL,
+    ENV_PORT,
+    ENV_REPO_ROOT,
+    ENV_TRANSPORT,
+    ServerConfig,
+    validate_repo_root,
+)
+
+
+def test_missing_repo_root_raises_config_error(monkeypatch):
+    """未设置 YASA_MCP_REPO_ROOT -> 抛 ConfigError。"""
+    monkeypatch.delenv(ENV_REPO_ROOT, raising=False)
+    with pytest.raises(ConfigError):
+        validate_repo_root()
+
+
+def test_empty_repo_root_raises_config_error(monkeypatch):
+    """YASA_MCP_REPO_ROOT 为空字符串 -> 抛 ConfigError。"""
+    monkeypatch.setenv(ENV_REPO_ROOT, "   ")
+    with pytest.raises(ConfigError):
+        validate_repo_root()
+
+
+def test_non_existent_repo_root_raises_config_error(monkeypatch, tmp_path):
+    """YASA_MCP_REPO_ROOT 指向不存在/非目录路径 -> 抛 ConfigError。"""
+    missing = str(tmp_path / "does-not-exist")
+    monkeypatch.setenv(ENV_REPO_ROOT, missing)
+    with pytest.raises(ConfigError):
+        validate_repo_root()
+
+
+def test_valid_repo_root_returns_abs_path(monkeypatch, tmp_path):
+    """合法目录 -> 返回规范化绝对路径。"""
+    monkeypatch.setenv(ENV_REPO_ROOT, str(tmp_path))
+    result = validate_repo_root()
+    assert result == os.path.abspath(str(tmp_path))
+
+
+def test_from_env_uses_defaults(monkeypatch, tmp_path):
+    """只配置合法 REPO_ROOT，其余走默认值。"""
+    monkeypatch.setenv(ENV_REPO_ROOT, str(tmp_path))
+    monkeypatch.delenv(ENV_TRANSPORT, raising=False)
+    monkeypatch.delenv(ENV_LOG_LEVEL, raising=False)
+    monkeypatch.delenv(ENV_PORT, raising=False)
+
+    config = ServerConfig.from_env()
+    assert config.transport == "stdio"
+    assert config.log_level == "info"
+    assert config.port == 8765
+    assert config.repo_root == os.path.abspath(str(tmp_path))
+
+
+def test_from_env_cli_overrides_env(monkeypatch, tmp_path):
+    """命令行参数优先级应高于环境变量。"""
+    monkeypatch.setenv(ENV_REPO_ROOT, str(tmp_path))
+    monkeypatch.setenv(ENV_TRANSPORT, "http")
+    monkeypatch.setenv(ENV_PORT, "9999")
+
+    config = ServerConfig.from_env(transport="stdio", port=8765)
+    # CLI 显式传入的 stdio 覆盖环境变量的 http
+    assert config.transport == "stdio"
+    # CLI 显式传入的 8765 覆盖环境变量的 9999
+    assert config.port == 8765
+
+
+def test_from_env_invalid_transport_raises(monkeypatch, tmp_path):
+    """非法 transport -> 抛 ConfigError。"""
+    monkeypatch.setenv(ENV_REPO_ROOT, str(tmp_path))
+    monkeypatch.setenv(ENV_TRANSPORT, "carrier-pigeon")
+    with pytest.raises(ConfigError):
+        ServerConfig.from_env()
+
+
+def test_from_env_invalid_log_level_raises(monkeypatch, tmp_path):
+    """非法 log_level -> 抛 ConfigError。"""
+    monkeypatch.setenv(ENV_REPO_ROOT, str(tmp_path))
+    monkeypatch.setenv(ENV_LOG_LEVEL, "loud")
+    with pytest.raises(ConfigError):
+        ServerConfig.from_env()
+
+
+def test_from_env_invalid_port_raises(monkeypatch, tmp_path):
+    """非法端口 -> 抛 ConfigError。"""
+    monkeypatch.setenv(ENV_REPO_ROOT, str(tmp_path))
+    monkeypatch.setenv(ENV_PORT, "not-a-number")
+    with pytest.raises(ConfigError):
+        ServerConfig.from_env()

--- a/tests/test_healthz.py
+++ b/tests/test_healthz.py
@@ -1,0 +1,34 @@
+# -*- coding: utf-8 -*-
+"""
+test_healthz.py —— 健康检查接口测试
+===================================
+
+覆盖验收标准：HTTP 模式下 GET /healthz 返回 200 与固定 JSON。
+"""
+from __future__ import annotations
+
+from starlette.testclient import TestClient
+
+from yasa_mcp import SERVER_NAME, SERVER_VERSION, TRANSPORTS_SUPPORTED
+from yasa_mcp.server import mcp
+
+
+def test_healthz_returns_200_and_fixed_json():
+    """GET /healthz 应返回 200 + 脚手架约定的固定结构。"""
+    app = mcp.http_app(transport="streamable-http")
+    with TestClient(app) as client:
+        resp = client.get("/healthz")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["status"] == "ok"
+        assert data["server_name"] == SERVER_NAME
+        assert data["version"] == SERVER_VERSION
+        assert data["transports_supported"] == TRANSPORTS_SUPPORTED
+
+
+def test_healthz_method_restricted_to_get():
+    """POST /healthz 应返回 405（仅允许 GET）。"""
+    app = mcp.http_app(transport="streamable-http")
+    with TestClient(app) as client:
+        resp = client.post("/healthz")
+        assert resp.status_code == 405

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -1,0 +1,56 @@
+# -*- coding: utf-8 -*-
+"""
+test_logging.py —— 日志输出格式与分级测试
+=========================================
+
+覆盖验收标准：不同日志级别下，日志输出格式与过滤是否正确。
+"""
+from __future__ import annotations
+
+import logging
+
+from yasa_mcp.config import LOGGER_NAME, LOG_LEVEL_MAP
+from yasa_mcp.logging_config import setup_logging
+
+
+def test_setup_logging_returns_shared_logger():
+    """setup_logging 应返回统一 logger（名称 yasa_mcp）。"""
+    logger = setup_logging("info")
+    assert logger.name == LOGGER_NAME
+
+
+def test_log_level_mapping():
+    """级别字符串应正确映射到 logging 级别。"""
+    assert LOG_LEVEL_MAP["debug"] == logging.DEBUG
+    assert LOG_LEVEL_MAP["info"] == logging.INFO
+    assert LOG_LEVEL_MAP["warn"] == logging.WARNING
+    assert LOG_LEVEL_MAP["error"] == logging.ERROR
+
+
+def test_debug_logging_not_emitted_at_info_level(caplog):
+    """级别设为 info 时，debug 日志不应被输出（过滤生效）。"""
+    setup_logging("info")
+    logger = logging.getLogger(LOGGER_NAME)
+
+    with caplog.at_level(logging.INFO, logger=LOGGER_NAME):
+        logger.debug("this is a debug line")
+        logger.info("this is an info line")
+
+    messages = [r.message for r in caplog.records]
+    assert "this is an info line" in messages
+    assert "this is a debug line" not in messages
+
+
+def test_log_format_contains_expected_fields(caplog):
+    """日志应包含时间 / 级别 / logger 名 / 消息 等统一格式字段。"""
+    setup_logging("info")
+    logger = logging.getLogger(LOGGER_NAME)
+
+    with caplog.at_level(logging.INFO, logger=LOGGER_NAME):
+        logger.info("健康检查通过")
+
+    assert any("健康检查通过" in record.message for record in caplog.records)
+    # 记录中应携带级别与 logger 名
+    record = next(r for r in caplog.records if "健康检查通过" in r.message)
+    assert record.levelname == "INFO"
+    assert record.name == LOGGER_NAME

--- a/tests/test_registration.py
+++ b/tests/test_registration.py
@@ -1,0 +1,96 @@
+# -*- coding: utf-8 -*-
+"""
+test_registration.py —— 工具注册机制测试
+========================================
+
+覆盖验收标准：@mcp_tool 装饰器 + auto_discover_tools 自动发现注册是否生效。
+"""
+from __future__ import annotations
+
+from tests.conftest import run
+
+from yasa_mcp.decorators import _MCP_TOOL_META_ATTR
+from yasa_mcp.registry import auto_discover_tools
+
+
+def test_mcp_tool_marks_function():
+    """@mcp_tool 装饰的函数应带有注册元数据（name / description）。"""
+    from yasa_mcp.decorators import mcp_tool
+
+    @mcp_tool(name="demo", description="演示工具")
+    async def demo() -> dict:
+        return {"ok": True}
+
+    meta = getattr(demo, _MCP_TOOL_META_ATTR)
+    assert meta["name"] == "demo"
+    assert meta["description"] == "演示工具"
+
+
+def test_mcp_tool_defaults_to_function_name():
+    """未显式指定 name 时，应默认使用函数名；description 默认用 docstring 首行。"""
+    from yasa_mcp.decorators import mcp_tool
+
+    @mcp_tool()
+    async def auto_named_tool() -> dict:
+        """这是工具描述"""
+        return {"ok": True}
+
+    meta = getattr(auto_named_tool, _MCP_TOOL_META_ATTR)
+    assert meta["name"] == "auto_named_tool"
+    assert meta["description"] == "这是工具描述"
+
+
+def test_auto_discover_registers_ping():
+    """auto_discover_tools 应自动发现 tools/ 目录下的 ping 并注册。"""
+    from fastmcp import FastMCP
+
+    mcp = FastMCP("test-discover")
+    registered = auto_discover_tools(mcp)
+    assert "ping" in registered
+
+
+def test_auto_discover_is_idempotent():
+    """对同一实例重复调用 auto_discover_tools 不应重复注册 / 报错。"""
+    from fastmcp import FastMCP
+
+    mcp = FastMCP("test-idem")
+    first = auto_discover_tools(mcp)
+    second = auto_discover_tools(mcp)
+    # 第一次注册到 ping；第二次已全部注册过，返回空列表（不重复、不报错）
+    assert first == ["ping"]
+    assert second == []
+
+
+def test_ping_discoverable_in_tools_list():
+    """已注册的 ping 应可通过 tools/list 被 AI 客户端发现。"""
+    from fastmcp import FastMCP
+
+    mcp = FastMCP("test-list")
+    auto_discover_tools(mcp)
+
+    async def _list():
+        tools = await mcp.list_tools()
+        return [t.name for t in tools]
+
+    assert "ping" in run(_list())
+
+
+def test_ping_callable_returns_fixed_structure():
+    """调用 ping 应返回脚手架约定的固定结构。"""
+    from fastmcp import FastMCP
+
+    mcp = FastMCP("test-ping")
+    auto_discover_tools(mcp)
+
+    async def _call():
+        result = await mcp.call_tool("ping", {})
+        return result.content[0].text
+
+    import json
+
+    payload = json.loads(run(_call()))
+    assert payload["status"] == "ok"
+    assert payload["server_name"] == "yasa-mcp"
+    assert payload["version"] == "0.1.0"
+    assert "stdio" in payload["transports_supported"]
+    assert "streamable-http" in payload["transports_supported"]

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -1,0 +1,94 @@
+# -*- coding: utf-8 -*-
+"""
+test_validation.py —— 入参校验与错误处理测试
+============================================
+
+覆盖验收标准：
+    * 必填字符串参数为空 -> 标准化错误 INVALID_PARAM；
+    * 类型不匹配 / 缺必填  -> fastmcp ValidationError；
+    * 工具内部抛错      -> 标准化错误 INTERNAL_ERROR（不崩溃服务）。
+"""
+from __future__ import annotations
+
+import json
+
+import pytest
+from fastmcp.exceptions import ValidationError
+
+from tests.conftest import run
+
+
+def _call(mcp, name: str, arguments: dict):
+    async def _c():
+        return await mcp.call_tool(name, arguments)
+
+    return run(_c())
+
+
+def test_required_empty_string_returns_invalid_param(make_tool_server):
+    """必填字符串传空串/纯空格 -> 返回 INVALID_PARAM 标准化错误。"""
+    async def greet(name: str) -> str:
+        return f"hi {name}"
+
+    mcp, name = make_tool_server(name="greet", func=greet)
+
+    result = _call(mcp, name, {"name": ""})
+    payload = json.loads(result.content[0].text)
+    assert payload["status"] == "error"
+    assert payload["error"]["code"] == "INVALID_PARAM"
+    assert payload["error"]["type"] == "ValidationError"
+
+    # 纯空格同样判定为空
+    result2 = _call(mcp, name, {"name": "   "})
+    payload2 = json.loads(result2.content[0].text)
+    assert payload2["error"]["code"] == "INVALID_PARAM"
+
+
+def test_type_mismatch_raises_validation_error(make_tool_server):
+    """类型不匹配（如 str 传给 int 参数）-> fastmcp ValidationError。"""
+    async def add(a: int, b: int) -> int:
+        return a + b
+
+    mcp, name = make_tool_server(name="add", func=add)
+
+    with pytest.raises(ValidationError):
+        _call(mcp, name, {"a": 1, "b": "not-a-number"})
+
+
+def test_missing_required_param_raises_validation_error(make_tool_server):
+    """缺少必填参数 -> fastmcp ValidationError。"""
+    async def add(a: int, b: int) -> int:
+        return a + b
+
+    mcp, name = make_tool_server(name="add", func=add)
+
+    with pytest.raises(ValidationError):
+        _call(mcp, name, {"a": 1})
+
+
+def test_tool_exception_returns_internal_error(make_tool_server):
+    """工具内部抛异常 -> 返回 INTERNAL_ERROR 标准化错误，服务不崩溃。"""
+    async def boom() -> str:
+        raise RuntimeError("boom!")
+
+    mcp, name = make_tool_server(name="boom", func=boom)
+
+    result = _call(mcp, name, {})
+    payload = json.loads(result.content[0].text)
+    assert payload["status"] == "error"
+    assert payload["error"]["code"] == "INTERNAL_ERROR"
+    assert payload["error"]["type"] == "RuntimeError"
+
+
+def test_sync_tool_exception_returns_internal_error(make_tool_server):
+    """同步工具抛异常同样被捕获为标准错误。"""
+    def boom_sync() -> str:
+        raise ValueError("sync boom")
+
+    mcp, name = make_tool_server(name="boom_sync", func=boom_sync)
+
+    result = _call(mcp, name, {})
+    payload = json.loads(result.content[0].text)
+    assert payload["status"] == "error"
+    assert payload["error"]["code"] == "INTERNAL_ERROR"
+    assert payload["error"]["type"] == "ValueError"

--- a/yasa_mcp/README.md
+++ b/yasa_mcp/README.md
@@ -1,0 +1,219 @@
+# YASA-MCP 统一运行底座脚手架（bootstrap_mcp_framework）
+
+> Issue #129 · 为 YASA 对外开放的所有 MCP 工具搭建统一的 Server 框架
+
+YASA-MCP 是 YASA-Engine 面向大模型开放的原子化程序分析 API。本脚手架为后续
+全部 MCP 工具提供**统一的运行底座**：工具注册机制、双传输模式、入参校验、
+错误处理、日志与健康检查。
+
+- **技术栈**：Python 3.10+ / [fastmcp](https://github.com/jlowin/fastmcp) 3.x / click / pydantic / uvicorn / pytest
+- **传输模式**：`stdio`（默认，供 Claude Desktop / Cline 等本地客户端调用）、`streamable-http`（HTTP 网络模式）
+
+---
+
+## 目录结构
+
+```
+yasa_mcp/
+  __init__.py        # 服务固定元信息（server_name / version / transports）
+  __main__.py        # 命令行入口（python -m yasa_mcp）
+  config.py          # 配置加载 + YASA_MCP_REPO_ROOT 强校验（CLI > 环境变量 > 默认值）
+  errors.py          # 标准化错误结构
+  logging_config.py  # 分级日志
+  decorators.py      # @mcp_tool 统一注册装饰器（校验 + 错误捕获）
+  registry.py        # auto_discover_tools：启动时自动扫描 tools/ 目录注册工具
+  server.py          # FastMCP 实例、/healthz、run_server 双模式启动
+  transport/
+    http.py          # streamable-http 传输层（uvicorn）
+  tools/
+    ping.py          # 演示工具：探测服务在线状态
+tests/               # pytest 单元测试
+```
+
+---
+
+## 快速开始
+
+### 1. 安装依赖
+
+```bash
+pip install -r requirements-dev.txt   # 运行 + 测试依赖
+```
+
+### 2. 设置环境变量（必填）
+
+`YASA_MCP_REPO_ROOT` 指向**待分析代码仓库的根目录**，启动时会强制校验：
+
+```bash
+# Windows (cmd)
+set YASA_MCP_REPO_ROOT=D:\path\to\your\repo
+
+# Windows (PowerShell)
+$env:YASA_MCP_REPO_ROOT = "D:\path\to\your\repo"
+
+# Mac / Linux
+export YASA_MCP_REPO_ROOT=/path/to/your/repo
+```
+
+未设置或指向不存在路径时，启动会给出友好错误提示并以退出码 1 结束。
+
+### 3. 启动服务
+
+```bash
+# stdio 模式（默认，供 Claude Desktop / Cline / MCP Inspector 调用）
+python -m yasa_mcp --transport stdio
+
+# HTTP 模式（streamable-http），默认绑定 127.0.0.1:8765
+python -m yasa_mcp --transport http --port 8765
+```
+
+| 启动参数 | 类型 | 默认值 | 说明 |
+| --- | --- | --- | --- |
+| `--transport` | stdio / http | stdio | 传输模式 |
+| `--port` | int | 8765 | HTTP 模式监听端口 |
+| `--log-level` | debug / info / warn / error | info | 日志级别 |
+
+### 4. 健康检查
+
+HTTP 模式下访问 `GET /healthz` 应返回 200：
+
+```bash
+curl http://127.0.0.1:8765/healthz
+# {"status":"ok","server_name":"yasa-mcp","version":"0.1.0","transports_supported":["stdio","streamable-http"]}
+```
+
+---
+
+## 客户端配置
+
+### Claude Desktop
+
+编辑 `claude_desktop_config.json`（macOS 位于 `~/Library/Application Support/Claude/`，
+Windows 位于 `%APPDATA%\Claude\`）。
+
+**stdio 模式：**
+
+```json
+{
+  "mcpServers": {
+    "yasa-mcp": {
+      "command": "python",
+      "args": ["-m", "yasa_mcp", "--transport", "stdio"],
+      "env": {
+        "YASA_MCP_REPO_ROOT": "D:\\path\\to\\your\\repo"
+      }
+    }
+  }
+}
+```
+
+**HTTP 模式（需先手动启动服务）：**
+
+```json
+{
+  "mcpServers": {
+    "yasa-mcp": {
+      "type": "http",
+      "url": "http://127.0.0.1:8765/mcp"
+    }
+  }
+}
+```
+
+### Cline
+
+在 Cline 的 MCP 服务器设置中添加：
+
+```json
+{
+  "mcpServers": {
+    "yasa-mcp": {
+      "command": "python",
+      "args": ["-m", "yasa_mcp", "--transport", "stdio"],
+      "env": {
+        "YASA_MCP_REPO_ROOT": "D:\\path\\to\\your\\repo"
+      }
+    }
+  }
+}
+```
+
+### MCP Inspector 调试
+
+```bash
+# 方式一：先设好环境变量，再启动 Inspector 交互式输入命令
+npx @modelcontextprotocol/inspector
+
+# 方式二：直接传入启动命令（Inspector 会自动带上 stdio 子进程）
+npx @modelcontextprotocol/inspector python -m yasa_mcp --transport stdio
+```
+
+启动后在 Inspector 界面应能看到 `ping` 工具，点击调用返回：
+
+```json
+{
+  "status": "ok",
+  "server_name": "yasa-mcp",
+  "version": "0.1.0",
+  "transports_supported": ["stdio", "streamable-http"]
+}
+```
+
+---
+
+## 新增一个 MCP 工具
+
+新增工具**无需修改任何框架核心代码**，三步完成：
+
+1. 在 `yasa_mcp/tools/` 下新建模块文件（如 `yasa_mcp/tools/greet.py`）；
+2. 用 `@mcp_tool` 装饰 tool 函数（框架会自动做 pydantic 类型校验、必填非空校验、异常兜底）；
+3. 重启服务，工具被 `auto_discover_tools()` 自动扫描注册。
+
+```python
+# yasa_mcp/tools/greet.py
+from typing import Any, Dict
+from yasa_mcp.decorators import mcp_tool
+
+
+@mcp_tool(name="greet", description="向用户打招呼")
+async def greet(name: str, times: int = 1) -> Dict[str, Any]:
+    """返回打招呼消息。
+
+    Args:
+        name:  用户名称（必填，空串会被框架拦下）。
+        times: 重复次数（可选，默认 1）。
+    """
+    return {"message": ("你好 " + name) * times}
+```
+
+要点：
+
+- **签名即规范**：fastmcp 依据函数签名自动生成 pydantic 参数模型，无需手写 Schema；
+- **必填非空**：必填字符串参数传空串/纯空格，返回 `INVALID_PARAM` 标准化错误；
+- **异常兜底**：工具内任何异常都被捕获，返回 `INTERNAL_ERROR` 标准化错误，服务不崩溃；
+- **文档即描述**：`description` 缺省时取 docstring 首行。
+
+### 标准化错误结构
+
+```json
+{
+  "status": "error",
+  "error": {
+    "code": "INVALID_PARAM | INTERNAL_ERROR",
+    "type": "Python 异常类型名",
+    "message": "人类可读错误信息",
+    "params": { "触发错误的入参快照": "..." }
+  }
+}
+```
+
+---
+
+## 单元测试
+
+```bash
+pytest tests/ -v
+```
+
+覆盖：工具注册机制、参数校验（空串 / 类型不匹配 / 缺必填）、异常兜底、
+日志分级与格式、配置强校验、`/healthz` 健康检查。

--- a/yasa_mcp/__init__.py
+++ b/yasa_mcp/__init__.py
@@ -1,0 +1,34 @@
+# -*- coding: utf-8 -*-
+"""
+yasa_mcp —— YASA-Engine [OSS26] MCP 统一运行底座脚手架
+=====================================================
+
+为 YASA 对外开放的所有 MCP 工具提供统一的 Server 框架：
+    * 工具注册机制（@mcp_tool 装饰器 + tools/ 目录自动发现）
+    * 双传输模式（stdio / streamable-http）
+    * 入参校验（pydantic 类型校验 + 必填字符串非空校验）
+    * 统一错误处理（标准化错误 JSON，工具抛错不崩溃服务）
+    * 分级日志与 /healthz 健康检查
+
+典型用法：
+    pip install -r requirements.txt
+    set YASA_MCP_REPO_ROOT=D:\\path\\to\\repo
+    python -m yasa_mcp --transport stdio
+    python -m yasa_mcp --transport http --port 8765
+"""
+from __future__ import annotations
+
+# ---------------------------------------------------------------------------
+# 服务固定元信息（ping 与 /healthz 共用，保证返回一致）
+# ---------------------------------------------------------------------------
+SERVER_NAME = "yasa-mcp"
+SERVER_VERSION = "0.1.0"
+TRANSPORTS_SUPPORTED = ["stdio", "streamable-http"]
+
+__version__ = SERVER_VERSION
+__all__ = [
+    "SERVER_NAME",
+    "SERVER_VERSION",
+    "TRANSPORTS_SUPPORTED",
+    "__version__",
+]

--- a/yasa_mcp/__main__.py
+++ b/yasa_mcp/__main__.py
@@ -1,0 +1,73 @@
+# -*- coding: utf-8 -*-
+"""
+__main__.py —— 命令行入口，支持 python -m yasa_mcp
+===================================================
+
+支持的启动方式：
+    python -m yasa_mcp --transport stdio                  # stdio（默认，AI 客户端调用）
+    python -m yasa_mcp --transport http --port 8765       # HTTP 网络模式
+
+命令行参数（click 实现）：
+    --transport  可选 stdio / http，默认 stdio
+    --port       可选，HTTP 端口，默认 8765
+    --log-level  可选 debug / info / warn / error，默认 info
+
+启动前必须设置环境变量 YASA_MCP_REPO_ROOT（指向待分析代码仓库根目录），
+缺失 / 非法时会在启动阶段给出友好提示并退出。
+"""
+from __future__ import annotations
+
+import click
+
+from yasa_mcp.config import ConfigError, ServerConfig
+from yasa_mcp.server import run_server
+
+
+@click.command(
+    name="yasa-mcp",
+    help="YASA-Engine [OSS26] MCP 统一运行底座脚手架启动器",
+)
+@click.option(
+    "--transport",
+    type=click.Choice(["stdio", "http"], case_sensitive=False),
+    default="stdio",
+    show_default=True,
+    help="传输模式：stdio（默认，供 Claude Desktop/Cline 调用）或 http（网络模式）",
+)
+@click.option(
+    "--port",
+    type=int,
+    default=8765,
+    show_default=True,
+    help="HTTP 模式监听端口（默认 8765）",
+)
+@click.option(
+    "--log-level",
+    type=click.Choice(["debug", "info", "warn", "error"], case_sensitive=False),
+    default="info",
+    show_default=True,
+    help="日志级别（默认 info）",
+)
+def main(transport: str, port: int, log_level: str) -> None:
+    """
+    YASA-MCP 启动入口：组装配置 -> 校验环境变量 -> 启动服务。
+
+    注意：环境变量 YASA_MCP_REPO_ROOT 的强制校验在
+    ServerConfig.from_env() 内部完成，为空/非法会直接抛 ConfigError。
+    """
+    try:
+        config = ServerConfig.from_env(
+            transport=transport,
+            port=port,
+            log_level=log_level,
+        )
+    except ConfigError as exc:
+        # 配置缺失 / 非法：友好红色提示 + 非 0 退出码
+        click.secho(f"\n[YASA-MCP 配置错误]\n{exc}", fg="red", err=True)
+        raise click.exceptions.Exit(code=1)
+
+    run_server(config)
+
+
+if __name__ == "__main__":
+    main()

--- a/yasa_mcp/config.py
+++ b/yasa_mcp/config.py
@@ -1,0 +1,158 @@
+# -*- coding: utf-8 -*-
+"""
+config.py —— 配置加载与环境变量强制校验
+=======================================
+
+职责：
+    1. 集中管理所有环境变量名常量，避免字符串散落各处；
+    2. 强制校验必填环境变量 YASA_MCP_REPO_ROOT，为空 / 非法直接抛 ConfigError；
+    3. 提供 ServerConfig 数据类，统一承载服务运行配置；
+    4. 提供分级日志初始化函数 setup_logging。
+
+优先级约定：命令行参数 > 环境变量 > 默认值。
+"""
+from __future__ import annotations
+
+import logging
+import os
+from dataclasses import dataclass, field
+from typing import List, Optional
+
+# ---------------------------------------------------------------------------
+# 环境变量名常量（后续新增配置项时，在此追加常量并在 from_env() 同步读取即可）
+# ---------------------------------------------------------------------------
+ENV_REPO_ROOT = "YASA_MCP_REPO_ROOT"    # 必填：待分析的代码仓库根目录
+ENV_LOG_LEVEL = "YASA_MCP_LOG_LEVEL"    # 可选：日志级别，默认 info
+ENV_PORT       = "YASA_MCP_PORT"        # 可选：HTTP 端口，默认 8765
+ENV_TRANSPORT  = "YASA_MCP_TRANSPORT"   # 可选：传输模式，默认 stdio
+
+# 合法取值集合（供命令行 / 环境变量双重校验）
+VALID_TRANSPORTS = ("stdio", "http")
+VALID_LOG_LEVELS = ("debug", "info", "warn", "error")
+
+# 日志级别字符串 -> logging 级别 映射表
+LOG_LEVEL_MAP = {
+    "debug": logging.DEBUG,
+    "info":  logging.INFO,
+    "warn":  logging.WARNING,
+    "error": logging.ERROR,
+}
+
+# 项目统一 logger 名称：所有模块共享同一个 logger，便于分级管理
+LOGGER_NAME = "yasa_mcp"
+
+
+class ConfigError(Exception):
+    """配置错误：环境变量缺失 / 非法时抛出，由命令行入口层捕获并友好提示。"""
+
+
+# ---------------------------------------------------------------------------
+# 强制校验
+# ---------------------------------------------------------------------------
+def validate_repo_root() -> str:
+    """
+    强制校验环境变量 YASA_MCP_REPO_ROOT（脚手架必做动作）。
+
+    规则：
+        - 未设置或为空值  -> 直接抛出 ConfigError，提示用户先配置；
+        - 指向的路径不存在 / 不是目录 -> 抛出 ConfigError。
+    通过后返回规范化后的绝对路径。
+    """
+    raw = os.environ.get(ENV_REPO_ROOT, "").strip()
+    if not raw:
+        raise ConfigError(
+            f"[YASA-MCP] 环境变量 {ENV_REPO_ROOT} 未配置或为空！\n"
+            f"请先设置该环境变量，指向待分析的代码仓库根目录，例如：\n"
+            f"  Windows   : set {ENV_REPO_ROOT}=D:\\path\\to\\repo\n"
+            f"  Mac/Linux : export {ENV_REPO_ROOT}=/path/to/repo"
+        )
+
+    # 归一化为绝对路径，兼容 Windows 反斜杠 / 正斜杠写法
+    root = os.path.abspath(raw)
+    if not os.path.isdir(root):
+        raise ConfigError(
+            f"[YASA-MCP] 环境变量 {ENV_REPO_ROOT} 指向的路径不存在或不是目录：{root}"
+        )
+    return root
+
+
+# ---------------------------------------------------------------------------
+# 配置对象
+# ---------------------------------------------------------------------------
+@dataclass
+class ServerConfig:
+    """
+    服务运行配置（纯数据类，无业务逻辑）。
+
+    优先级：命令行参数 > 环境变量 > 默认值。
+    """
+
+    server_name: str = "yasa-mcp"          # 服务名（MCP server name）
+    version: str = "0.1.0"                 # 服务版本号
+    repo_root: str = ""                    # 仓库根目录（必填，由校验保证）
+    transport: str = "stdio"               # 传输模式：stdio / http
+    port: int = 8765                       # HTTP 模式监听端口
+    log_level: str = "info"                # 日志级别
+    transports_supported: List[str] = field(  # 声明的传输能力（ping 固定返回使用）
+        default_factory=lambda: ["stdio", "streamable-http"]
+    )
+
+    @classmethod
+    def from_env(
+        cls,
+        transport: Optional[str] = None,
+        port: Optional[int] = None,
+        log_level: Optional[str] = None,
+    ) -> "ServerConfig":
+        """
+        从「命令行参数 + 环境变量 + 默认值」组装配置（优先级 CLI > env > 默认）。
+
+        同时完成两项强校验：
+            - YASA_MCP_REPO_ROOT 必填（缺失 / 非目录 -> ConfigError）；
+            - transport / log_level 取值合法（非法 -> ConfigError）。
+
+        Args:
+            transport: CLI 传入的 --transport（None 表示未指定，回落到 env/默认）。
+            port:      CLI 传入的 --port。
+            log_level: CLI 传入的 --log-level。
+
+        Raises:
+            ConfigError: 环境变量缺失 / 取值非法时。
+        """
+        # ---- 必填项：仓库根目录（无论哪种启动方式都必须配置） ----
+        repo_root = validate_repo_root()
+
+        # ---- 传输模式：CLI > env > 默认 stdio ----
+        transport_value = transport or os.environ.get(ENV_TRANSPORT, "stdio").strip().lower()
+        if transport_value not in VALID_TRANSPORTS:
+            raise ConfigError(
+                f"[YASA-MCP] 非法的传输模式: {transport_value!r}，"
+                f"可选值: {', '.join(VALID_TRANSPORTS)}"
+            )
+
+        # ---- 日志级别：CLI > env > 默认 info ----
+        log_level_value = log_level or os.environ.get(ENV_LOG_LEVEL, "info").strip().lower()
+        if log_level_value not in VALID_LOG_LEVELS:
+            raise ConfigError(
+                f"[YASA-MCP] 非法的日志级别: {log_level_value!r}，"
+                f"可选值: {', '.join(VALID_LOG_LEVELS)}"
+            )
+
+        # ---- 端口：CLI > env > 默认 8765 ----
+        if port is None:
+            try:
+                port = int(os.environ.get(ENV_PORT, "8765").strip())
+            except ValueError:
+                raise ConfigError(
+                    f"[YASA-MCP] 环境变量 {ENV_PORT} 不是合法整数: "
+                    f"{os.environ.get(ENV_PORT)!r}"
+                )
+        if not (0 < port < 65536):
+            raise ConfigError(f"[YASA-MCP] 非法端口号: {port}（需在 1-65535 之间）")
+
+        return cls(
+            repo_root=repo_root,
+            transport=transport_value,
+            port=port,
+            log_level=log_level_value,
+        )

--- a/yasa_mcp/decorators.py
+++ b/yasa_mcp/decorators.py
@@ -1,0 +1,171 @@
+# -*- coding: utf-8 -*-
+"""
+decorators.py —— 统一工具注册装饰器 @mcp_tool
+=============================================
+
+脚手架为后续业务 MCP Tool 提供的「唯一注册入口」。在 tools/ 目录下
+用 @mcp_tool 装饰的函数，会在服务启动时被 auto_discover_tools() 自动扫描、
+注册到 FastMCP 实例，全程无需修改任何框架核心代码。
+
+装饰器底层封装了三件事：
+    1. 入参类型校验   —— 由 fastmcp / pydantic 依据函数签名自动生成参数模型；
+    2. 必填非空校验   —— 对「必填（无默认值）的字符串参数」额外做非空增强；
+    3. 统一异常捕获   —— 工具抛错不崩溃服务，转为标准化错误 JSON 返回。
+
+典型用法：
+    from yasa_mcp.decorators import mcp_tool
+
+    @mcp_tool(name="add", description="两数相加")
+    async def add(a: int, b: int) -> int:
+        \"\"\"两数相加\"\"\"
+        return a + b
+
+说明：装饰器内部用 functools.wraps + __signature__ 保留原函数签名，
+      fastmcp 才能据此自动生成 pydantic 参数模型（类型校验 / 必填校验）。
+"""
+from __future__ import annotations
+
+import functools
+import inspect
+import logging
+from typing import Any, Callable, Dict, Optional
+
+from yasa_mcp.config import LOGGER_NAME
+from yasa_mcp.errors import make_error_response
+
+logger = logging.getLogger(LOGGER_NAME)
+
+# 用于在函数对象上标记 tool 元数据的属性名
+_MCP_TOOL_META_ATTR = "_mcp_tool_meta"
+
+
+# ---------------------------------------------------------------------------
+# 内部校验逻辑
+# ---------------------------------------------------------------------------
+def _validate_required_not_empty(
+    func: Callable, kwargs: Dict[str, Any]
+) -> Optional[Dict[str, Any]]:
+    """
+    对「必填（无默认值）的字符串参数」做非空校验。
+
+    空串 / 纯空格判定为非法，返回标准化错误；校验通过返回 None。
+    （类型校验交给 fastmcp / pydantic 在调用前自动完成，这里只做非空增强）
+    """
+    try:
+        sig = inspect.signature(func)
+    except (TypeError, ValueError):
+        return None  # 拿不到签名则不校验，保持向后兼容
+
+    for name, param in sig.parameters.items():
+        # 跳过带默认值（即可选）的参数
+        if param.default is not inspect.Parameter.empty:
+            continue
+        value = kwargs.get(name)
+        # 只对字符串做非空判断；None / 其它类型交由 pydantic 处理
+        if isinstance(value, str) and not value.strip():
+            return make_error_response(
+                code="INVALID_PARAM",
+                message=f"参数 '{name}' 不能为空",
+                error_type="ValidationError",
+                params={name: value},
+            )
+    return None
+
+
+def _invoke_with_error_guard(
+    func: Callable, kwargs: Dict[str, Any]
+) -> Any:
+    """
+    统一异常捕获：调用原函数，抛错时返回标准化错误 JSON（不崩溃服务）。
+
+    注意：调用 async 函数返回的是协程（此时异常尚未发生），因此本函数
+    不负责 await；由外层包装函数在 try 块内 await。这里只兜底「同步抛错」
+    （如函数体在创建协程前抛错、或同步函数直接抛错）。
+    """
+    try:
+        return func(**kwargs)
+    except Exception as exc:  # noqa: BLE001 —— 工具层异常必须全量兜底
+        return _build_error_response(exc, kwargs, getattr(func, "__name__", func))
+
+
+def _build_error_response(exc: Exception, kwargs: Dict[str, Any], func_name: str) -> Dict[str, Any]:
+    """把异常转为标准化错误 JSON。"""
+    logger.error("Tool '%s' 执行异常: %s: %s", func_name, type(exc).__name__, exc)
+    return make_error_response(
+        code="INTERNAL_ERROR",
+        message=f"{type(exc).__name__}: {exc}",
+        error_type=type(exc).__name__,
+        params=kwargs,
+    )
+
+
+# ---------------------------------------------------------------------------
+# 注册装饰器
+# ---------------------------------------------------------------------------
+def mcp_tool(
+    name: Optional[str] = None,
+    description: Optional[str] = None,
+) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
+    """
+    将函数标记为 MCP Tool，并注入统一的校验 / 错误处理逻辑。
+
+    用法：:
+
+        @mcp_tool(name="ping", description="探测服务在线状态")
+        async def ping() -> dict:
+            return {"status": "ok"}
+
+    Args:
+        name:        MCP tool 名称（tools/list 中显示；缺省用函数名）。
+        description: tool 描述（tools/list 中显示；缺省用 docstring 首行）。
+
+    Returns:
+        装饰器。返回的包装函数保留了原始函数签名（供 fastmcp 生成参数模型），
+        同时带有 _mcp_tool_meta 元数据，供 auto_discover_tools 识别注册。
+    """
+    def decorator(func: Callable[..., Any]) -> Callable[..., Any]:
+        tool_name = name or func.__name__
+        tool_desc = description or _docstring_first_line(func)
+        meta: Dict[str, Any] = {"name": tool_name, "description": tool_desc}
+        setattr(func, _MCP_TOOL_META_ATTR, meta)
+
+        @functools.wraps(func)
+        async def async_wrapper(*args: Any, **kwargs: Any) -> Any:
+            err = _validate_required_not_empty(func, kwargs)
+            if err is not None:
+                return err
+            try:
+                result = func(**kwargs)
+                if inspect.isawaitable(result):
+                    result = await result  # 在 try 内 await，异常才能被捕获
+                return result
+            except Exception as exc:  # noqa: BLE001 —— 工具层异常必须全量兜底
+                return _build_error_response(exc, kwargs, tool_name)
+
+        @functools.wraps(func)
+        def sync_wrapper(*args: Any, **kwargs: Any) -> Any:
+            err = _validate_required_not_empty(func, kwargs)
+            if err is not None:
+                return err
+            return _invoke_with_error_guard(func, kwargs)
+
+        # 选择与原函数一致的包装形态（异步工具 / 同步工具）
+        wrapper = async_wrapper if inspect.iscoroutinefunction(func) else sync_wrapper
+
+        # 显式保留原函数签名，fastmcp 据此生成 pydantic 参数模型
+        wrapper.__signature__ = inspect.signature(func)
+        setattr(wrapper, _MCP_TOOL_META_ATTR, meta)
+
+        logger.debug("Tool marked for registration: %s", tool_name)
+        return wrapper
+
+    return decorator
+
+
+def _docstring_first_line(func: Callable) -> str:
+    """提取函数 docstring 的第一行作为默认描述。"""
+    doc = inspect.getdoc(func)
+    if not doc:
+        return ""
+    first = doc.strip().splitlines()[0].strip()
+    return first

--- a/yasa_mcp/errors.py
+++ b/yasa_mcp/errors.py
@@ -1,0 +1,49 @@
+# -*- coding: utf-8 -*-
+"""
+errors.py —— 标准化错误结构
+============================
+
+所有 tool 抛出的异常统一转换为如下结构返回（工具不崩溃服务）：
+
+    {
+        "status": "error",
+        "error": {
+            "code":     "机器可读错误码",
+            "type":     "Python 异常类型名",
+            "message":  "人类可读错误信息",
+            "params":   "触发错误的入参快照（调试用）",
+        },
+    }
+"""
+from __future__ import annotations
+
+from typing import Any, Dict, Optional
+
+
+def make_error_response(
+    code: str,
+    message: str,
+    error_type: str = "Error",
+    params: Optional[Dict[str, Any]] = None,
+) -> Dict[str, Any]:
+    """
+    构造统一的「标准化错误」返回结构。
+
+    Args:
+        code:       机器可读错误码，如 INVALID_PARAM / REGEX_ERROR。
+        message:    人类可读错误信息。
+        error_type: Python 异常类型名（默认 "Error"）。
+        params:     触发错误的入参快照（调试用，可省略）。
+
+    Returns:
+        符合框架约定结构的错误字典，可直接作为 tool 返回值。
+    """
+    return {
+        "status": "error",
+        "error": {
+            "code": code,
+            "type": error_type,
+            "message": message,
+            "params": params or {},
+        },
+    }

--- a/yasa_mcp/logging_config.py
+++ b/yasa_mcp/logging_config.py
@@ -1,0 +1,43 @@
+# -*- coding: utf-8 -*-
+"""
+logging_config.py —— 统一日志配置
+=================================
+
+提供分级日志初始化函数 setup_logging()，全项目共用 LOGGER_NAME
+（yasa_mcp）对应的 logger，输出统一格式，便于调试与运维。
+"""
+from __future__ import annotations
+
+import logging
+
+from yasa_mcp.config import LOG_LEVEL_MAP, LOGGER_NAME
+
+# 统一日志格式：时间 级别 模块: 消息
+LOG_FORMAT = "%(asctime)s [%(levelname)s] %(name)s: %(message)s"
+
+
+def setup_logging(level: str = "info") -> logging.Logger:
+    """
+    初始化项目统一 logger，并设置指定日志级别。
+
+    Args:
+        level: 日志级别字符串，可选 debug / info / warn / error。
+
+    Returns:
+        配置完成后的统一 logger（yasa_mcp）。
+    """
+    log_level = LOG_LEVEL_MAP.get(level, logging.INFO)
+
+    logger = logging.getLogger(LOGGER_NAME)
+    logger.setLevel(log_level)
+
+    # 避免重复添加 handler（测试多次调用 setup_logging 时保持幂等）
+    if not any(isinstance(h, logging.StreamHandler) for h in logger.handlers):
+        handler = logging.StreamHandler()
+        handler.setFormatter(logging.Formatter(LOG_FORMAT))
+        logger.addHandler(handler)
+
+    # 防止日志向更上层的 root logger 重复传播
+    logger.propagate = False
+
+    return logger

--- a/yasa_mcp/registry.py
+++ b/yasa_mcp/registry.py
@@ -1,0 +1,97 @@
+# -*- coding: utf-8 -*-
+"""
+registry.py —— Tool 自动发现与注册
+==================================
+
+服务启动时调用 auto_discover_tools()，自动扫描 yasa_mcp/tools/ 目录下
+所有使用 @mcp_tool 装饰器标记的函数，并注册到 FastMCP 实例。
+
+后续 Tool 开发者只需：
+    1. 在 yasa_mcp/tools/ 下新建一个模块文件；
+    2. 用 @mcp_tool(name=..., description=...) 装饰 tool 函数。
+无需修改任何框架核心代码，重启服务即自动生效。
+"""
+from __future__ import annotations
+
+import importlib
+import logging
+import pkgutil
+from typing import Any, Callable, List, Set
+
+from fastmcp import FastMCP
+
+from yasa_mcp.config import LOGGER_NAME
+from yasa_mcp.decorators import _MCP_TOOL_META_ATTR
+
+logger = logging.getLogger(LOGGER_NAME)
+
+
+def auto_discover_tools(
+    mcp: FastMCP,
+    package_name: str = "yasa_mcp.tools",
+) -> List[str]:
+    """
+    自动扫描指定包下所有模块，把被 @mcp_tool 装饰的函数注册到 FastMCP 实例。
+
+    Args:
+        mcp:         FastMCP 实例。
+        package_name: 要扫描的包名（默认 "yasa_mcp.tools"）。
+
+    Returns:
+        已注册的 tool 名称列表（顺序与扫描到的模块顺序一致）。
+
+    Note:
+        已在当前 mcp 实例上注册过的工具会被跳过（幂等，避免重复注册报错）。
+        幂等状态挂在 mcp 实例属性上，因此不同 mcp 实例互不影响。
+    """
+    registered: List[str] = []
+
+    # 每个 mcp 实例单独记录已注册集合，保证多次调用 / 多实例测试互不干扰
+    registered_set: Set[str] = getattr(mcp, "_yasa_registered_tools", set())
+
+    try:
+        package = importlib.import_module(package_name)
+    except ImportError as exc:
+        logger.error("无法导入 tools 包 '%s': %s", package_name, exc)
+        return registered
+
+    package_path = getattr(package, "__path__", None)
+    if package_path is None:
+        logger.error("包 '%s' 没有 __path__，无法扫描", package_name)
+        return registered
+
+    for _, module_name, _ in pkgutil.iter_modules(package_path):
+        full_name = f"{package_name}.{module_name}"
+        try:
+            module = importlib.import_module(full_name)
+        except Exception as exc:  # noqa: BLE001 —— 单个 tool 失败不阻塞整体启动
+            logger.error("导入 tool 模块 '%s' 失败: %s", full_name, exc)
+            continue
+
+        for attr_name in dir(module):
+            obj = getattr(module, attr_name)
+            meta = getattr(obj, _MCP_TOOL_META_ATTR, None)
+            # 仅注册「被 @mcp_tool 装饰」的可调用对象
+            if meta is None or not callable(obj):
+                continue
+
+            tool_name: str = meta.get("name") or attr_name
+            if tool_name in registered_set:
+                logger.debug("Tool '%s' 已注册，跳过", tool_name)
+                continue
+
+            try:
+                mcp.tool(
+                    name=tool_name,
+                    description=meta.get("description") or "",
+                )(obj)
+            except Exception as exc:  # noqa: BLE001
+                logger.error("注册 tool '%s' 失败: %s", tool_name, exc)
+                continue
+
+            registered_set.add(tool_name)
+            registered.append(tool_name)
+            logger.info("已注册 tool: %s", tool_name)
+
+    setattr(mcp, "_yasa_registered_tools", registered_set)
+    return registered

--- a/yasa_mcp/server.py
+++ b/yasa_mcp/server.py
@@ -1,0 +1,95 @@
+# -*- coding: utf-8 -*-
+"""
+server.py —— MCP 服务核心（双传输模式）
+=======================================
+
+本文件负责：
+    1. 创建全局唯一的 FastMCP 实例（统一运行底座）；
+    2. 内置 /healthz 健康检查接口（HTTP 模式下可访问）；
+    3. 启动时自动发现并注册 yasa_mcp/tools/ 下的所有工具；
+    4. stdio 模式启动（默认，供 Claude Desktop / Cline / MCP Inspector 调用）；
+    5. streamable-http 模式启动（HTTP 网络模式）。
+
+注意：本脚手架针对 fastmcp 3.x 编写（见 requirements.txt）。
+"""
+from __future__ import annotations
+
+import logging
+
+from fastmcp import FastMCP
+from starlette.requests import Request
+from starlette.responses import JSONResponse
+
+from yasa_mcp import SERVER_NAME, SERVER_VERSION, TRANSPORTS_SUPPORTED
+from yasa_mcp.config import LOGGER_NAME, ServerConfig
+from yasa_mcp.logging_config import setup_logging
+from yasa_mcp.registry import auto_discover_tools
+
+logger = logging.getLogger(LOGGER_NAME)
+
+
+# ===========================================================================
+# 全局唯一 MCP 服务实例 —— 后续所有代码分析 Tool 都注册到这个实例上
+# ===========================================================================
+mcp = FastMCP(
+    name=SERVER_NAME,
+    version=SERVER_VERSION,
+    instructions=(
+        "YASA-Engine [OSS26] MCP 统一运行底座脚手架。"
+        "本服务是代码分析能力的统一注册底座，工具通过 tools/ 目录自动发现。"
+    ),
+)
+
+
+# ---------------------------------------------------------------------------
+# HTTP 健康检查接口：GET /healthz -> 200 + JSON
+# 通过 fastmcp 3.x 的 custom_route 直接注册到 FastMCP 应用上。
+# ---------------------------------------------------------------------------
+@mcp.custom_route("/healthz", methods=["GET"])
+async def healthz(request: Request) -> JSONResponse:
+    """健康检查：返回 200 与服务基础信息（AI 客户端 / 运维探活用）。"""
+    return JSONResponse(
+        {
+            "status": "ok",
+            "server_name": SERVER_NAME,
+            "version": SERVER_VERSION,
+            "transports_supported": TRANSPORTS_SUPPORTED,
+        }
+    )
+
+
+# ---------------------------------------------------------------------------
+# 启动函数
+# ---------------------------------------------------------------------------
+def run_server(config: ServerConfig) -> None:
+    """
+    根据配置启动服务：初始化日志 -> 自动注册工具 -> 选择传输模式。
+
+    Args:
+        config: 服务运行配置（由 ServerConfig.from_env() 组装并校验）。
+
+    Raises:
+        ValueError: transport 取值非法（正常情况下由 from_env 提前拦截）。
+    """
+    setup_logging(config.log_level)
+    logger.info(
+        "YASA-MCP 启动: server=%s v%s, transport=%s, repo_root=%s",
+        config.server_name,
+        config.version,
+        config.transport,
+        config.repo_root,
+    )
+
+    registered = auto_discover_tools(mcp)
+    logger.info("自动注册完成，共 %d 个工具: %s", len(registered), registered)
+
+    if config.transport == "stdio":
+        logger.info("stdio 模式启动中...")
+        mcp.run(transport="stdio", show_banner=False)
+    elif config.transport == "http":
+        logger.info("streamable-http 模式启动中，端口 %s...", config.port)
+        from yasa_mcp.transport.http import run_http
+
+        run_http(mcp, config.port, log_level=config.log_level)
+    else:
+        raise ValueError(f"不支持的传输模式: {config.transport}")

--- a/yasa_mcp/tools/__init__.py
+++ b/yasa_mcp/tools/__init__.py
@@ -1,0 +1,16 @@
+# -*- coding: utf-8 -*-
+"""
+yasa_mcp.tools —— 业务 MCP 工具包
+=================================
+
+框架启动时通过 auto_discover_tools() 自动扫描本目录下所有模块，
+把被 @mcp_tool 装饰的函数注册为 MCP Tool。
+
+新增工具三步：
+    1. 在本目录新建模块文件（如 search_code_by_keyword.py）；
+    2. 用 @mcp_tool(name=..., description=...) 装饰 tool 函数；
+    3. 重启服务，工具自动生效（无需修改框架核心代码）。
+"""
+from __future__ import annotations
+
+__all__ = []

--- a/yasa_mcp/tools/ping.py
+++ b/yasa_mcp/tools/ping.py
@@ -1,0 +1,40 @@
+# -*- coding: utf-8 -*-
+"""
+tools/ping.py —— 演示工具 ping
+===============================
+
+用于验证脚手架「自动发现 + 注册」机制是否生效的最小工具：
+    * 被 @mcp_tool 装饰；
+    * 无需修改任何框架核心代码，启动时自动注册到 FastMCP；
+    * 固定返回结构，便于 AI 客户端验证连通性。
+"""
+from __future__ import annotations
+
+from typing import Any, Dict
+
+from yasa_mcp import SERVER_NAME, SERVER_VERSION, TRANSPORTS_SUPPORTED
+from yasa_mcp.decorators import mcp_tool
+
+
+@mcp_tool(
+    name="ping",
+    description="Ping 演示工具：探测服务是否在线，返回固定结构",
+)
+async def ping() -> Dict[str, Any]:
+    """
+    探测服务是否在线。
+
+    固定返回结构：
+        {
+          "status": "ok",
+          "server_name": "yasa-mcp",
+          "version": "0.1.0",
+          "transports_supported": ["stdio", "streamable-http"]
+        }
+    """
+    return {
+        "status": "ok",
+        "server_name": SERVER_NAME,
+        "version": SERVER_VERSION,
+        "transports_supported": TRANSPORTS_SUPPORTED,
+    }

--- a/yasa_mcp/transport/__init__.py
+++ b/yasa_mcp/transport/__init__.py
@@ -1,0 +1,9 @@
+# -*- coding: utf-8 -*-
+"""
+yasa_mcp.transport —— 传输层封装
+
+    http.py    streamable-http 模式启动（uvicorn + fastmcp http_app）
+"""
+from __future__ import annotations
+
+__all__ = []

--- a/yasa_mcp/transport/http.py
+++ b/yasa_mcp/transport/http.py
@@ -1,0 +1,78 @@
+# -*- coding: utf-8 -*-
+"""
+transport/http.py —— streamable-http 传输模式
+=============================================
+
+将 FastMCP 实例的 http_app() 挂到 uvicorn 上运行。
+
+安全默认（本脚手架的安全基线）：
+    * 默认只绑定 127.0.0.1（仅本机可访问，不暴露到局域网/公网）；
+    * 启用 fastmcp 的 host_origin_protection="auto" 来源保护
+      （对 loopback 主机自动校验 Host/Origin，阻止跨站 / 伪造来源请求）；
+    * 不设置通配 CORS（allowed_origins / allowed_hosts 默认 None，
+      由 fastmcp 按 loopback 主机自动收紧）。
+
+如需对外提供服务（如局域网 / 远程客户端访问），必须显式传入
+allowed_origins / allowed_hosts / host，框架不会默认开放。
+"""
+from __future__ import annotations
+
+import logging
+from typing import List, Optional
+
+import uvicorn
+from fastmcp import FastMCP
+
+from yasa_mcp.config import LOGGER_NAME
+
+logger = logging.getLogger(LOGGER_NAME)
+
+
+def run_http(
+    mcp: FastMCP,
+    port: int = 8765,
+    host: str = "127.0.0.1",
+    log_level: Optional[str] = "info",
+    allowed_origins: Optional[List[str]] = None,
+    allowed_hosts: Optional[List[str]] = None,
+) -> None:
+    """
+    以 streamable-http 模式启动 MCP 服务（阻塞式）。
+
+    Args:
+        mcp:            FastMCP 实例（已注册好工具）。
+        port:           监听端口。
+        host:           监听地址（默认 127.0.0.1，仅本机访问）。
+        log_level:      uvicorn 日志级别。
+        allowed_origins: 显式放行的 Origin（默认 None -> 由 fastmcp
+                         host_origin_protection="auto" 按 loopback 自动收紧）。
+        allowed_hosts:   显式放行的 Host（默认 None，同上）。
+
+    Note:
+        默认安全策略不开放到网络。若确需远程访问，请显式传参，例如：
+            run_http(mcp, host="0.0.0.0", port=8765,
+                     allowed_origins=["https://your-client.example.com"])
+    """
+    # fastmcp 3.x 的 http_app 返回 Starlette 应用；/healthz 已挂在实例上
+    app = mcp.http_app(
+        transport="streamable-http",
+        host_origin_protection="auto",  # loopback 主机自动校验 Host/Origin
+        allowed_origins=allowed_origins,
+        allowed_hosts=allowed_hosts,
+    )
+
+    logger.info("streamable-http 服务监听 http://%s:%s/", host, port)
+    logger.info("健康检查: GET http://%s:%s/healthz", host, port)
+    if host not in ("127.0.0.1", "localhost", "::1"):
+        logger.warning(
+            "绑定到非本机地址 %s，服务将对网络可见；请确认 allowed_origins / "
+            "allowed_hosts 已按需配置。",
+            host,
+        )
+
+    uvicorn.run(
+        app,
+        host=host,
+        port=port,
+        log_level=log_level or "info",
+    )


### PR DESCRIPTION
为 YASA 对外开放的所有 MCP 工具搭建统一 Server 框架：
- @mcp_tool 统一注册装饰器 + tools/ 目录自动发现注册
- stdio / streamable-http 双传输模式
- pydantic 类型校验 + 必填非空校验 + 标准化错误处理
- /healthz 健康检查、分级日志、配置强校验（YASA_MCP_REPO_ROOT）
- 演示工具 ping；pytest 单测覆盖注册/校验/日志/配置/健康检查

Fixes #129
Issue #129：为 YASA 对外开放的所有 MCP 工具搭建统一 Server 框架（bootstrap_mcp_framework）。

实现内容

工具注册机制：@mcp_tool 统一装饰器 + auto_discover_tools() 自动扫描 yasa_mcp/tools/ 目录，新增工具只需新建文件，零改核心代码
双传输模式：stdio（默认）与 streamable-http（HTTP 网络模式）
入参校验：pydantic 依据函数签名自动生成参数模型 + 必填字符串非空校验增强
错误处理：工具抛错不崩溃服务，统一转为标准化错误 JSON（INVALID_PARAM / INTERNAL_ERROR）
健康检查：HTTP 模式 GET /healthz 返回 200
配置强校验：必填环境变量 YASA_MCP_REPO_ROOT，CLI 参数 > 环境变量 > 默认值
分级日志：--log-level 控制 debug/info/warn/error
演示工具：ping，固定返回结构
安全默认：HTTP 默认绑定 127.0.0.1 + fastmcp host_origin_protection="auto"，不默认暴露到网络

验收标准核对

python -m yasa_mcp --transport stdio 启动并通过 MCP 通信（initialize / tools/list 验证通过）
python -m yasa_mcp --transport http --port 8765 启动，GET /healthz 返回 200
注册 demo tool ping，客户端可发现并调用
README 包含 Claude Desktop 配置示例（claude_desktop_config.json）
单元测试覆盖：tool 注册、参数校验失败、日志输出格式

运行方式

pip install -r requirements-dev.txt
export YASA_MCP_REPO_ROOT=/path/to/repo
python -m yasa_mcp --transport stdio # 或 --transport http --port 8765

测试

pytest tests/ -v # 26 passed

Fixes #129